### PR TITLE
feat(cd): Use pinned tags instead of latest

### DIFF
--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -68,7 +68,7 @@ runs:
 
     # Must upload artifact for output file parameter to have effect
     - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@v0
+      uses: anchore/sbom-action@v0.13.2
       id: sbom_spdx
       with:
         image: ${{ steps.meta.outputs.scan_image }}
@@ -84,7 +84,7 @@ runs:
         dependency-snapshot: false
 
     - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@v0
+      uses: anchore/sbom-action@v0.13.2
       id: sbom_cyclonedx
       with:
         image: ${{ steps.meta.outputs.scan_image }}
@@ -108,7 +108,7 @@ runs:
     
     # Don't fail during report generation
     - name: Vulnerability analysis of SBOM
-      uses: anchore/scan-action@v3
+      uses: anchore/scan-action@v3.3.3
       id: grype_analysis_sarif
       if: ${{ steps.sbom_report.outputs.files_exists == 'true' }}
       with:
@@ -120,7 +120,7 @@ runs:
     # Don't fail during report generation
     # JSON format will report  any ignored rules
     - name: Vulnerability analysis of SBOM
-      uses: anchore/scan-action@v3
+      uses: anchore/scan-action@v3.3.3
       id: grype_analysis_json
       if: ${{ steps.sbom_report.outputs.files_exists == 'true' }}
       with:
@@ -165,7 +165,7 @@ runs:
     # Notify grype quick scan results in table format
     # Table format will supress any specified ignore rules
     - name: Inspect Vulnerability analysis of SBOM
-      uses: anchore/scan-action@v3
+      uses: anchore/scan-action@v3.3.3
       if: ${{ steps.sbom_report.outputs.files_exists == 'true' }}
       with:
         sbom: ${{ steps.meta.outputs.sbom_spdx_file }}


### PR DESCRIPTION
Dependabot now supports updating dependencies of composite actions and monitors for dependencies in subfolders (mono repo) as part of https://github.com/dependabot/dependabot-core. This can be also viewed from "insights -> dependency-graph -> dependabot " and send out PRs for version updates.

Ex: https://github.com/Scimia/public-shared-actions/pulls

I have reverted to using pinned tags on the `anchore/sbom-action` and `anchore/scan-action` for dependabot to send out new PR's once this is merged to test it out.