### PR TITLE
fix(cd): only pass input flag to trivy action when docker tar is present

### DIFF
--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -164,15 +164,22 @@ runs:
           ${{ steps.meta.outputs.grype_json_file }}
         if-no-files-found: warn
 
+    - name: Check docker OCI tar existence
+      uses: andstor/file-existence-action@v2
+      id: docker_tar
+      with:
+        files: "${{ steps.meta.outputs.scan_image }}"
+
     - name: Generate docker-cis JSON report
       uses: docker://ghcr.io/aquasecurity/trivy:0.37.2
       id: cis_json
       with:
         entrypoint: trivy
-        args: "image --input ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f json --severity ${{ env.severity }} -o ${{ steps.meta.outputs.cis_json_file }}"
+        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f json --severity ${{ env.severity }} -o ${{ steps.meta.outputs.cis_json_file }}"
       env:
         compliance: docker-cis
         severity: ${{ steps.meta.outputs.global_severity_cutoff }}
+        input: ${{ steps.docker_tar.outputs.files_exists == 'true' && '--input' || '' }}
 
     - name: upload docker-cis JSON report
       uses: actions/upload-artifact@v3
@@ -198,8 +205,9 @@ runs:
       uses: docker://ghcr.io/aquasecurity/trivy:0.37.2
       with:
         entrypoint: trivy
-        args: "image --input ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f table --severity ${{ env.severity }} --exit-code ${{ env.exit-code }}"
+        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f table --severity ${{ env.severity }} --exit-code ${{ env.exit-code }}"
       env:
         exit-code: ${{ (steps.meta.outputs.global_enforce_build_failure == 'true' || inputs.fail_build == 'true') && '1' || '0' }}
         compliance: docker-cis
         severity: ${{ steps.meta.outputs.global_severity_cutoff }}
+        input: ${{ steps.docker_tar.outputs.files_exists == 'true' && '--input' || '' }}


### PR DESCRIPTION
To compensate for trivy's inability to take an image name with the  '--input' flag (an issue with trivy has been raised [HERE](https://github.com/aquasecurity/trivy/issues/3672)), these changes check for the existence of a docker.tar file and optionally pass the '--input' flag to the trivy action if a tar file is present. 