### PR TITLE
feat: add input params for SBOM upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test Shared Actions
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+    - main
+  release:
+    types: [published]
+
+
+jobs:
+  test-scan-docker-image:
+    name: Test Scan Docker Image
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./security-actions/scan-docker-image
+      with:
+        image: kong/kong-gateway-dev:latest # no particular reason for the choice of image or tag, just an image for tests
+        upload_to_workflow: true
+  test-scan-docker-image-upload-release:
+    name: Test Scan Docker Image - with upload (release) params
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./security-actions/scan-docker-image
+      with:
+        image: kong/kong-gateway-dev:latest # no particular reason for the choice of image or tag, just an image for tests
+        upload_to_workflow: true
+        upload_to_release: true

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -39,7 +39,7 @@ inputs:
   upload_to_workflow:
     description: 'upload SBOM artifact generated in a particular workflow'
     required: false
-    default: false
+    default: true # to be reverted once https://github.com/anchore/sbom-action/pull/411 is merged
     type: choice
     options:
     - 'true'

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -36,6 +36,22 @@ inputs:
     options:
     - 'true'
     - 'false'
+  upload_to_workflow:
+    description: 'upload SBOM artifact generated in a particular workflow'
+    required: false
+    default: false
+    type: choice
+    options:
+    - 'true'
+    - 'false'
+  upload_to_release:
+    description: 'upload release SBOM artifacts'
+    required: false
+    default: false
+    type: choice
+    options:
+    - 'true'
+    - 'false'
 
 outputs:
   cis-json-report:
@@ -82,8 +98,8 @@ runs:
         format: spdx-json
         artifact-name: ${{ steps.meta.outputs.sbom_spdx_file }}
         output-file: ${{ steps.meta.outputs.sbom_spdx_file }}
-        upload-artifact: true
-        upload-release-assets: false
+        upload-artifact: ${{ inputs.upload_sbom_artifact }}
+        upload-release-assets: ${{ inputs.upload_release_sbom_artifacts }}
         dependency-snapshot: false
 
     - name: Generate CycloneDX SBOM Using Syft
@@ -98,8 +114,8 @@ runs:
         format: cyclonedx-json
         artifact-name: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
         output-file: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
-        upload-artifact: true
-        upload-release-assets: false
+        upload-artifact: ${{ inputs.upload_to_workflow }}
+        upload-release-assets: ${{ inputs.upload_to_release }}
         dependency-snapshot: false
     
     - name: Check SBOM files existence


### PR DESCRIPTION
Add input params to enable / disable the upload of SBOM assets -- both for commit and release workflows.
Also, this PR introduces a very minimal GH Action to test the shared action.

KAG-739