### PR TITLE
feat(luacheck): Add luacode static analysis (#19)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,11 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+  
+  - package-ecosystem: "github-actions"
+    directory: "/code-check-actions/luacheck"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "github-actions"
+      include: "scope"

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -1,4 +1,4 @@
-name: Test Shared Actions
+name: Docker Scan Test
 
 on:
   pull_request:

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,23 @@
+name: Luacheck Test
+
+on:
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch: {}
+
+jobs:
+  test-luacheck:
+    env:
+      LUA_TEST_REPOSITORY: "Kong/lua-resty-lmdb"
+    runs-on: ubuntu-latest
+    name: Test Lua code analysis check
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{env.LUA_TEST_REPOSITORY}}
+          path: ${{env.LUA_TEST_REPOSITORY}}
+      - uses: ./code-check-actions/luacheck
+        with:
+          args: '--no-default-config --config ${{env.LUA_TEST_REPOSITORY}}/.luacheckrc ${{env.LUA_TEST_REPOSITORY}}'

--- a/code-check-actions/luacheck/README.md
+++ b/code-check-actions/luacheck/README.md
@@ -1,0 +1,67 @@
+# Lua Check - Github Action
+
+Luacheck is a static analyzer for Lua. The options for static analysis configuration can be used on the command line, put into a config file or directly into checked files as Lua comments.
+
+This action analyzes all changed lua files using [lunarmodules/luacheck](https://github.com/lunarmodules/luacheck).
+
+This action looks for any `cli` arguments and a deafult `.luacheckrc` config to derive the final configuaration as mentioned in [docs](https://luacheck.readthedocs.io/en/stable/cli.html#command-line-options)
+
+## User tracking
+
+Currently, these repos are using this action:
+
+[]
+
+## Inputs
+
+```yaml
+args: 
+    description: 'Arguments to luacheck'
+    required: 'false'
+    default: '.' # Default: Run luacheck on workspace dir 
+```
+
+## Action status
+The status outcome of the action will depend based on the follwing:
+
+- Exit code is 0 if no warnings or errors occurred.
+- Exit code is 1 if some warnings occurred but there were no syntax errors or invalid inline options.
+- Exit code is 2 if there were some syntax errors or invalid inline options.
+- Exit code is 3 if some files couldn’t be checked, typically due to an incorrect file name.
+- Exit code is 4 if there was a critical error (invalid CLI arguments, config, or cache file).
+
+## Example usage
+
+```yaml
+uses: Kong/public-shared-actions/code-check-actions/luacheck@main
+
+```
+
+## Detailed example
+
+```yaml
+name: Luacheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+    name: Lua code analysis check
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@04124efe7560d15e11ea2ba96c0df2989f68f1f4
+        with:
+          base_sha: ${{ github.event.workflow_run.head_sha }}
+      - uses: Kong/public-shared-actions/code-check-actions/luacheck@main
+        with:
+            args: "${{ steps.changed-files.outputs.all_changed_files }}"
+```

--- a/code-check-actions/luacheck/action.yml
+++ b/code-check-actions/luacheck/action.yml
@@ -1,0 +1,17 @@
+name: Luacheck satic analysis
+description: Static analysis of Lua
+author: 'Kong'
+inputs:
+  args:
+    description: 'arguments for Luacheck'
+    required: false
+    default: '.' # Scans workspace dir
+    
+runs:
+  using: composite
+  steps:
+
+    - name: Run Luacheck for static analysis
+      uses: lunarmodules/luacheck@v1
+      with:
+        args: "${{ inputs.args }}"


### PR DESCRIPTION
Description:
1. The action will output an exit code based on the luacheck [https://luacheck.readthedocs.io/en/stable/cli.html#command-line-options] and will fail on any warnings/errors
2. Downstream implementations of this workflow must configure how to proceed with the workflow in case of failure. 
3. The action runs as a docker container and mounts the current workspace into the container with `luacheck` as entry point.
4. It will use any specified cli args and a `.luacheckrc` configuration file by default in the workspace dir.