### PR TITLE
Revert SBOM action

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -12,8 +12,13 @@ jobs:
   test-scan-docker-image:
     name: Test Scan Docker Image
     runs-on: ubuntu-22.04
+    env:
+      IMAGE: kong/kong-gateway-dev:latest #particular reason for the choice of image: test multi arch image sbom
     steps:
     - uses: actions/checkout@v3
+
+    - name: Install regctl
+      uses: regclient/actions/regctl-installer@main
 
     - name: Login to DockerHub
       if: success()
@@ -22,6 +27,38 @@ jobs:
         username: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
 
-    - uses: ./security-actions/scan-docker-image
+    - name: Parse Architecture Specific Image Manifest Digests
+      id: image_manifest_metadata
+      run: |
+        manifest_list_exists="$(
+          if regctl manifest get "${IMAGE}" --format raw-body --require-list -v panic &> /dev/null; then
+            echo true
+          else
+            echo false
+          fi
+        )"
+        echo "manifest_list_exists=$manifest_list_exists"
+        echo "manifest_list_exists=$manifest_list_exists" >> $GITHUB_OUTPUT
+
+        amd64_sha="$(regctl image digest "${IMAGE}" --platform linux/amd64 || echo '')"
+        arm64_sha="$(regctl image digest "${IMAGE}" --platform linux/arm64 || echo '')"
+        echo "amd64_sha=$amd64_sha"
+        echo "amd64_sha=$amd64_sha" >> $GITHUB_OUTPUT
+        echo "arm64_sha=$arm64_sha"
+        echo "arm64_sha=$arm64_sha" >> $GITHUB_OUTPUT
+
+    - name: Scan AMD64 Image digest
+      id: sbom_action_amd64
+      if: steps.image_manifest_metadata.outputs.amd64_sha != ''
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@v1.1.0
       with:
-        image: kong/kong-gateway-dev:latest # no particular reason for the choice of image or tag, just an image for tests
+        asset_prefix: kong-gateway-dev-linux-amd64
+        image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
+
+    - name: Scan ARM64 Image digest
+      if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
+      id: sbom_action_arm64
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@v1.1.0
+      with:
+        asset_prefix: kong-gateway-dev-linux-arm64
+        image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}

--- a/code-check-actions/rustcheck/action.yml
+++ b/code-check-actions/rustcheck/action.yml
@@ -88,7 +88,7 @@ runs:
 
     # Must upload artifact for output file parameter to have effect
     - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.14.2
+      uses: anchore/sbom-action@v0.13.4
       id: sbom_spdx
       with:
         image: ${{ steps.meta.outputs.scan_image }}
@@ -104,7 +104,7 @@ runs:
         dependency-snapshot: false
 
     - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.14.2
+      uses: anchore/sbom-action@v0.13.4
       id: sbom_cyclonedx
       with:
         image: ${{ steps.meta.outputs.scan_image }}

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -71,7 +71,7 @@ runs:
 
     # Must upload artifact for output file parameter to have effect
     - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.14.2
+      uses: anchore/sbom-action@v0.13.4
       id: sbom_spdx
       with:
         image: ${{ steps.meta.outputs.scan_image }}
@@ -87,7 +87,7 @@ runs:
         dependency-snapshot: false
 
     - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.14.2
+      uses: anchore/sbom-action@v0.13.4
       id: sbom_cyclonedx
       with:
         image: ${{ steps.meta.outputs.scan_image }}


### PR DESCRIPTION
- Revert SBOM action wrapper to 0.13.4 and use syft 0.75 until https://github.com/anchore/sbom-action/issues/419 is resolved.
- Add test to track dependency updates on multi-arch images.

