### PR TITLE
autoupdate major version tag on release

### DIFF
--- a/.github/workflows/auto-tagger.yml
+++ b/.github/workflows/auto-tagger.yml
@@ -1,0 +1,11 @@
+name: Keep the versions up-to-date
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest

--- a/.github/workflows/build-sdk-js.yml
+++ b/.github/workflows/build-sdk-js.yml
@@ -1,8 +1,6 @@
 name: Build SDK JS
 
 on:
-  release:
-    types: [published]
   pull_request:
     branches:
     - main

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -1,8 +1,6 @@
 name: Docker Scan Test
 
 on:
-  release:
-    types: [published]
   pull_request:
     branches:
     - main

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,8 +1,6 @@
 name: Luacheck Test
 
 on:
-  release:
-    types: [published]
   pull_request:
     branches:
     - main

--- a/.github/workflows/rustcheck.yml
+++ b/.github/workflows/rustcheck.yml
@@ -1,8 +1,6 @@
 name: Rust checks
 
 on:
-  release:
-    types: [published]
   pull_request:
     branches:
     - main

--- a/.github/workflows/rustcheck.yml
+++ b/.github/workflows/rustcheck.yml
@@ -11,8 +11,12 @@ on:
     - '*'
   workflow_dispatch: {}
 
+env:
+  HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
+
 jobs:
   test-rust-checks:
+    if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
     env:
       RUST_TEST_REPOSITORY: "Kong/atc-router"
     outputs:


### PR DESCRIPTION
- Optimize workflow tests to run on tag creation instead of release published event
