### PR TITLE
fix: cleanup starting with newer PR versions [KHCP-7461]

### DIFF
--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -47,7 +47,7 @@ runs:
           echo "${pkgName}@${verToRemove}"
           prNumber=$(echo ${verToRemove} | sed 's/.*\-pr\.//g'| cut -d'.' -f 1)
 
-          if [[ ! -z $(echo ${openPRs} ||sed 's/\"//g'| sed 's/[\[\]]/,/g' | grep ",${prNumber},") ]]; then
+          if [[ ! -z $(echo ${openPRs} | sed 's/\"//g'| sed 's/\[/,/g' | sed 's/\]/,/g' | grep ",${prNumber},") ]]; then
             if [[ ! -z $(echo ${distTags}|grep "${verToRemove}") ]]; then
               echo "${pkgName}@${verToRemove}: belongs to open PR and tagged as PR preview, skip..."
               continue

--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -26,7 +26,7 @@ runs:
 
         # get the list of the "-pr." published version for the packages
         pkgDetails=$(npm view "${pkgName}" --json)
-        prVersions=($(echo ${pkgDetails}| jq -r '.versions' | grep '\-pr.'| sed 's/[,\"]//g'))
+        prVersions=($(echo ${pkgDetails}| jq -r '.versions' | grep '\-pr.'| tac | sed 's/[,\"]//g'))
 
         distTags=$(echo ${pkgDetails}|jq -r '."dist-tags"')
 

--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -47,7 +47,7 @@ runs:
           echo "${pkgName}@${verToRemove}"
           prNumber=$(echo ${verToRemove} | sed 's/.*\-pr\.//g'| cut -d'.' -f 1)
 
-          if [[ ! -z $(echo ${openPRs} | grep "\"${prNumber}\"") ]]; then
+          if [[ ! -z $(echo ${openPRs} ||sed 's/\"//g'| sed 's/[\[\]]/,/g' | grep ",${prNumber},") ]]; then
             if [[ ! -z $(echo ${distTags}|grep "${verToRemove}") ]]; then
               echo "${pkgName}@${verToRemove}: belongs to open PR and tagged as PR preview, skip..."
               continue

--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -53,6 +53,8 @@ runs:
               continue
             fi
           fi
+          echo "dos not belong to openPR, continue working..."
+          exit 0
 
           if [[ $(echo ${verDetails}|jq -r ".deprecated") == null ]]; then
             if [[ ! -z $(echo ${distTags}|grep "${verToRemove}") ]]; then

--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -27,6 +27,10 @@ runs:
         # get the list of the "-pr." published version for the packages
         pkgDetails=$(npm view "${pkgName}" --json)
         prVersions=($(echo ${pkgDetails}| jq -r '.versions' | grep '\-pr.'| tac | sed 's/[,\"]//g'))
+        if [[ -z "${prVersions}" ]]; then
+          echo "No preview versions found, exiting..."
+          exit 0
+        fi
 
         distTags=$(echo ${pkgDetails}|jq -r '."dist-tags"')
 

--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -53,8 +53,6 @@ runs:
               continue
             fi
           fi
-          echo "dos not belong to openPR, continue working..."
-          exit 0
 
           if [[ $(echo ${verDetails}|jq -r ".deprecated") == null ]]; then
             if [[ ! -z $(echo ${distTags}|grep "${verToRemove}") ]]; then


### PR DESCRIPTION
This is to attempt to cleanup newer PR preview package versions first. More chance to do something useful before 429 (rate limiting) error occurs. 