### PR TITLE
WIP: Enhance UX for SAST and SCA for and lua and rust

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -14,15 +14,16 @@ on:
 jobs:
   test-luacheck:
     env:
-      LUA_TEST_REPOSITORY: "Kong/lua-resty-lmdb"
+      LUA_TEST_REPOSITORY: "${{github.repository_owner}}/kong-ee"
     runs-on: ubuntu-latest
-    name: Test Lua code analysis check
+    name: Luacheck code analysis
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
         with:
           repository: ${{env.LUA_TEST_REPOSITORY}}
+          token: ${{secrets.SCIMIA_BOT_GITHUB_TOKEN}}
           path: ${{env.LUA_TEST_REPOSITORY}}
       - uses: ./code-check-actions/luacheck
         with:
-          args: '--no-default-config --config ${{env.LUA_TEST_REPOSITORY}}/.luacheckrc ${{env.LUA_TEST_REPOSITORY}}'
+          additional_args: '--no-default-config --config ${{env.LUA_TEST_REPOSITORY}}/.luacheckrc ${{env.LUA_TEST_REPOSITORY}}'

--- a/.github/workflows/rustcheck.yml
+++ b/.github/workflows/rustcheck.yml
@@ -1,4 +1,4 @@
-name: Rust checks
+name: Rust SCA and Lint Test
 
 on:
   pull_request:
@@ -12,23 +12,29 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  test-rust-checks:
+  test-rust-sca:
+    permissions:
+      # required for all workflows
+      security-events: write
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
     env:
-      RUST_TEST_REPOSITORY: "Kong/atc-router"
+      RUST_TEST_REPOSITORY: "${{github.repository_owner}}/atc-router"
     outputs:
       grype-report: ${{ steps.rust_checks.outputs.grype-sarif-report }}
       sbom-spdx-report: ${{ steps.rust_checks.outputs.sbom-spdx-report }}
       sbom-cyclonedx-report: ${{ steps.rust_checks.outputs.sbom-cyclonedx-report }}
     runs-on: ubuntu-latest
-    name: Rust scan and vulnerability SCA checks
+    name: Rust code analysis and SCA checks
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
         with:
           repository: ${{env.RUST_TEST_REPOSITORY}}
+          token: ${{secrets.SCIMIA_BOT_GITHUB_TOKEN}}
           path: ${{env.RUST_TEST_REPOSITORY}}
       - uses: ./code-check-actions/rustcheck
         with:
           asset_prefix: ${{env.RUST_TEST_REPOSITORY}}
           dir: ${{ github.workspace }}/${{env.RUST_TEST_REPOSITORY}}
-          token: ${{secrets.GITHUB_TOKEN}}

--- a/code-check-actions/luacheck/README.md
+++ b/code-check-actions/luacheck/README.md
@@ -15,7 +15,7 @@ Currently, these repos are using this action:
 ## Inputs
 
 ```yaml
-args: 
+additional_args: 
     description: 'Arguments to luacheck'
     required: 'false'
     default: '.' # Default: Run luacheck on workspace dir 
@@ -24,16 +24,17 @@ args:
 ## Action status
 The status outcome of the action will depend based on the follwing:
 
-- Exit code is 0 if no warnings or errors occurred.
+<!-- - Exit code is 0 if no warnings or errors occurred.
 - Exit code is 1 if some warnings occurred but there were no syntax errors or invalid inline options.
 - Exit code is 2 if there were some syntax errors or invalid inline options.
 - Exit code is 3 if some files couldn’t be checked, typically due to an incorrect file name.
-- Exit code is 4 if there was a critical error (invalid CLI arguments, config, or cache file).
+- Exit code is 4 if there was a critical error (invalid CLI arguments, config, or cache file). -->
 
+- Always exit with 0 even when there are warnings / errors and be non-blocking
 ## Example usage
 
 ```yaml
-uses: Kong/public-shared-actions/code-check-actions/luacheck@main
+uses: public-shared-actions/code-check-actions/luacheck@main
 
 ```
 
@@ -56,12 +57,19 @@ jobs:
     name: Lua code analysis check
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@04124efe7560d15e11ea2ba96c0df2989f68f1f4
+        uses: tj-actions/changed-files@04124efe7560d15e11ea2ba96c0df2989f68f1f4ith
         with:
-          base_sha: ${{ github.event.workflow_run.head_sha }}
+          files: |
+            **.lua
+            **.rockspec
+
       - uses: Kong/public-shared-actions/code-check-actions/luacheck@main
+        if: steps.changed-files-excluded.outputs.any_changed == 'true'
         with:
             args: "${{ steps.changed-files.outputs.all_changed_files }}"
 ```

--- a/code-check-actions/luacheck/action.yml
+++ b/code-check-actions/luacheck/action.yml
@@ -2,8 +2,12 @@ name: Luacheck satic analysis
 description: Static analysis of Lua
 author: 'Kong'
 inputs:
-  args:
+  additional_args:
     description: 'arguments for Luacheck'
+    required: false
+    default: '' # Scans workspace dir
+  files:
+    description: ' List of files, directories and rockspecs to check'
     required: false
     default: '.' # Scans workspace dir
     
@@ -13,5 +17,36 @@ runs:
 
     - name: Run Luacheck for static analysis
       uses: lunarmodules/luacheck@fcbdeacad00e643e0d78c56b9ba6d8b3c7fa584f
+      continue-on-error: true
       with:
-        args: "${{ inputs.args }}"
+        args: "${{ inputs.additional_args }} -c --codes --ranges --formatter JUnit -q ${{ inputs.files }} > luacheck_${{github.sha}}.xml"
+    
+    - name: Upload Luacheck results to artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: luacheck_results.zip
+        path: |
+          luacheck_${{github.sha}}.xml
+        if-no-files-found: warn
+
+#     - name: Print Luacheck results
+#       shell: bash
+#       run: | 
+#         cat luacheck_${{github.sha}}.xml
+
+    # when using the regular GITHUB_TOKEN, the check-run created by this step will be assigned to a
+    # random workflow in the GH UI. to prevent this, we can force the check-run to be created in a separate
+    # check-suite, which is created automatically if we use the credentials of a GitHub App
+    # Ref: https://github.com/EnricoMi/publish-unit-test-result-action/issues/181
+    - name: Luacheck Report
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: |
+          luacheck_${{github.sha}}.xml
+        check_name: Luacheck Report
+        comment_mode: always
+        action_fail: false
+
+  

--- a/code-check-actions/rustcheck/action.yml
+++ b/code-check-actions/rustcheck/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: ''
   dir: 
-    description: 'Speicify a directory to be checked and scanned'
+    description: 'Speicify a scan directory that must contain cargo.lock and cargo.toml'
     required: false
     default: '.'
   fail_build:
@@ -18,8 +18,8 @@ inputs:
     options:
     - 'true'
     - 'false'
-  token:
-    description: 'A Github PAT'
+  token: 
+    description: 'Github token to annotate files with findings'
     required: true
 
 outputs:
@@ -29,12 +29,6 @@ outputs:
   grype-sarif-report:
     description: 'vulnerability sarif report'
     value: ${{ steps.grype_analysis.outputs.sarif }}
-  sbom-spdx-report:
-    description: 'SBOM spdx report'
-    value: ${{ steps.meta.outputs.sbom_spdx_file }}
-  sbom-cyclonedx-report:
-    description: 'SBOM cyclonedx report'
-    value: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
 
 runs:
   using: composite
@@ -42,153 +36,103 @@ runs:
   
     - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f
       with:
-        profile: default
         toolchain: stable
-        components: rustfmt, clippy
+        components: clippy
 
     - name: Set Scan Job Metadata
       shell: bash
       id: meta
       env:
         DIR: ${{ inputs.dir }}
-        FILE: ${{ inputs.file }}
         ASSET_PREFIX: ${{ inputs.asset_prefix }}
       run: $GITHUB_ACTION_PATH/scripts/scan-metadata.sh
     
-     # fails with an error code / succeeds
-    # - uses: actions-rs/cargo@v1
+    - uses: Swatinem/rust-cache@v1
+
+    # - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b
     #   continue-on-error: true
     #   with:
-    #     command: "fmt"
-    #     args: "--all --manifest-path ${{ steps.meta.outputs.lint_path }}"
+    #     command: install
+    #     args: "clippy-sarif sarif-fmt"
 
-    # fails with an error code / succeeds
-    # Run as part of clippy
-    # - uses: actions-rs/cargo@v1
+    # - name: Run Cargo Clippy
+    #   shell: bash
     #   continue-on-error: true
-    #   with:
-    #     command: check
-    #     args: "--manifest-path ${{ steps.meta.outputs.lint_path }}"
+    #   run: |
+    #     cargo clippy --manifest-path ${{ steps.meta.outputs.manifest_path }} --message-format=json -- -W clippy::correctness -W clippy::cargo -W clippy::pedantic | clippy-sarif | tee rust_clippy_${{github.sha}}.sarif | sarif-fmt
 
-    # fail on any correctness lint groups 
-    # always warn other lint groups
-    - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b
+    # - name: Upload Rust Linting SARIF file to CodeQL
+    #   if: ${{ github.event.repository.visibility == 'public' }}
+    #   uses: github/codeql-action/upload-sarif@v2
+    #   with:
+    #     sarif_file: rust_clippy_${{github.sha}}.sarif
+    #     category: clippy_rust
+
+    - uses: actions-rs/clippy-check@v1
       continue-on-error: true
       with:
-        command: clippy # Runs all default clippy::all lints for warn mode
-        args: "--manifest-path ${{ steps.meta.outputs.lint_path }} -- -D clippy::correctness -W clippy::all -W clippy::cargo -W clippy::pedantic"
-
-    # - uses: auguwu/clippy-action@1.1.0
+        token: ${{ inputs.token }}
+        args: --manifest-path ${{ steps.meta.outputs.manifest_path }} -- -W clippy::correctness -W clippy::cargo -W clippy::pedantic
+        name: Rust Clippy Report
+   
+    # - name: Upload Rust Linting results to workflow
+    #   if: always()
+    #   uses: actions/upload-artifact@v3
     #   with:
-    #     token: ${{ inputs.token }}
-    #     working-directory: ${{ steps.meta.outputs.lint_path }}
-    #     warn: "all,cargo,pedantic"
-    #     deny: "correctness"
-    #     forbid: "restriction,nursery"
-
-    # Must upload artifact for output file parameter to have effect
-    - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.13.4
-      id: sbom_spdx
-      with:
-        image: ${{ steps.meta.outputs.scan_image }}
-        registry-username: ${{ inputs.registry_username }}
-        registry-password: ${{ inputs.registry_password }}
-        path: ${{ steps.meta.outputs.scan_dir }}
-        file: ${{ steps.meta.outputs.scan_file }}
-        format: spdx-json
-        artifact-name: ${{ steps.meta.outputs.sbom_spdx_file }}
-        output-file: ${{ steps.meta.outputs.sbom_spdx_file }}
-        upload-artifact: true
-        upload-release-assets: false
-        dependency-snapshot: false
-
-    - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.13.4
-      id: sbom_cyclonedx
-      with:
-        image: ${{ steps.meta.outputs.scan_image }}
-        registry-username: ${{ inputs.registry_username }}
-        registry-password: ${{ inputs.registry_password }} 
-        path: ${{ steps.meta.outputs.scan_dir }}
-        file: ${{ steps.meta.outputs.scan_file }}
-        format: cyclonedx-json
-        artifact-name: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
-        output-file: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
-        upload-artifact: true
-        upload-release-assets: false
-        dependency-snapshot: false
-    
-    - name: Check SBOM files existence
-      uses: andstor/file-existence-action@v2
-      id: sbom_report
-      with:
-        files: "${{ steps.meta.outputs.sbom_spdx_file }}, ${{ steps.meta.outputs.sbom_cyclonedx_file }}"
-        fail: true
+    #     name: rust_clippy_results.sarif
+    #     path: |
+    #       rust_clippy_${{github.sha}}.sarif
+    #     if-no-files-found: warn 
     
     # Don't fail during report generation
     - name: Vulnerability analysis of SBOM
       uses: anchore/scan-action@v3.3.5
-      id: grype_analysis_sarif
-      if: ${{ steps.sbom_report.outputs.files_exists == 'true' }}
+      continue-on-error: true
+      id: scan
       with:
-        sbom: ${{ steps.meta.outputs.sbom_spdx_file }}
+        path: ${{ steps.meta.outputs.scan_dir }}
         output-format: sarif
         fail-build: 'false'
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
-
-    # Don't fail during report generation
-    # JSON format will report  any ignored rules
-    - name: Vulnerability analysis of SBOM
-      uses: anchore/scan-action@v3.3.5
-      id: grype_analysis_json
-      if: ${{ steps.sbom_report.outputs.files_exists == 'true' }}
-      with:
-        sbom: ${{ steps.meta.outputs.sbom_spdx_file }}
-        output-format: json
-        fail-build: 'false'
-        severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+        add-cpes-if-none: true
     
-    - name: Check vulnerability analysis report existence
-      uses: andstor/file-existence-action@v2
-      id: grype_report
+    - name: Upload SARIF CVE analysis file to CodeQL
+      if: ${{ always() && github.event.repository.visibility == 'public' }}
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@v2
       with:
-        files: "${{ steps.grype_analysis_sarif.outputs.sarif }}, ${{ steps.grype_analysis_json.outputs.json }}"
-        fail: true
+        sarif_file: ${{ steps.scan.outputs.sarif }}
+        category: sca_rust
     
     # Grype CVE Action generates an ./results.sarif or ./results.report and no way to customize output file name
     # Hack to increase readability of grype artifacts attached to workflows and releases
     - name: Rename grype analysis report
       shell: bash
       run: |
-        mv ${{ steps.grype_analysis_sarif.outputs.sarif }} ${{ steps.meta.outputs.grype_sarif_file }}
-        mv ${{ steps.grype_analysis_json.outputs.json }} ${{ steps.meta.outputs.grype_json_file }}
-    
+        mv ${{ steps.scan.outputs.sarif }} ${{ steps.meta.outputs.grype_sarif_file }}
+
     - name: Upload grype analysis report
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.meta.outputs.grype_sarif_file }}
         path: |
           ${{ steps.meta.outputs.grype_sarif_file }}
-        if-no-files-found: warn 
-    
-    # Upload grype cve reports
-    - name: Upload grype analysis report
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ steps.meta.outputs.grype_json_file }}
-        path: |
-          ${{ steps.meta.outputs.grype_json_file }}
         if-no-files-found: warn
 
     # Fail based on severity and input parameters
     # Notify grype quick scan results in table format
     # Table format will supress any specified ignore rules
-    - name: Inspect Vulnerability analysis of SBOM
+    - name: Vulnerability Report
       uses: anchore/scan-action@v3.3.5
-      if: ${{ steps.sbom_report.outputs.files_exists == 'true' }}
       with:
-        sbom: ${{ steps.meta.outputs.sbom_spdx_file }}
+        path: ${{ steps.meta.outputs.scan_dir }}
         output-format: table
         fail-build: ${{ steps.meta.outputs.global_enforce_build_failure == 'true' && steps.meta.outputs.global_enforce_build_failure || inputs.fail_build }}
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+
+    # # Rust Clippy - Linting report
+    # - name:  Rust Linting Report - SARIF
+    #   shell: bash
+    #   run: |
+    #     cat rust_clippy_${{github.sha}}.sarif

--- a/code-check-actions/rustcheck/scripts/scan-metadata.sh
+++ b/code-check-actions/rustcheck/scripts/scan-metadata.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-readonly spdx_ext="sbom.spdx.json"
-readonly cyclonedx_ext="sbom.cyclonedx.json"
 readonly cve_json_ext="cve-report.json"
 readonly cve_sarif_ext="cve-report.sarif"
 
@@ -17,21 +15,13 @@ fi
 
 if [[ -n ${DIR} ]]; then
     echo "scan_dir=${DIR}" >> $GITHUB_OUTPUT
-    echo "lint_path=${DIR}/Cargo.toml" >> $GITHUB_OUTPUT
-fi
-
-if [[ -n ${FILE} ]]; then
-    echo "scan_file=${FILE}" >> $GITHUB_OUTPUT
+    echo "manifest_path=${DIR}/Cargo.toml" >> $GITHUB_OUTPUT
 fi
 
 if [[ -n ${ASSET_PREFIX} ]]; then
-    echo "sbom_spdx_file=${ASSET_PREFIX##*/}-${spdx_ext}" >> $GITHUB_OUTPUT
-    echo "sbom_cyclonedx_file=${ASSET_PREFIX##*/}-${cyclonedx_ext}" >> $GITHUB_OUTPUT
     echo "grype_json_file=${ASSET_PREFIX##*/}-${cve_json_ext}" >> $GITHUB_OUTPUT
     echo "grype_sarif_file=${ASSET_PREFIX##*/}-${cve_sarif_ext}" >> $GITHUB_OUTPUT
 else
-    echo "sbom_spdx_file=${spdx_ext}" >> $GITHUB_OUTPUT
-    echo "sbom_cyclonedx_file=${cyclonedx_ext}" >> $GITHUB_OUTPUT
     echo "grype_json_file=${cve_json_ext}" >> $GITHUB_OUTPUT
     echo "grype_sarif_file=${cve_sarif_ext}" >> $GITHUB_OUTPUT
 fi

--- a/code-check-actions/semgrep/README.md
+++ b/code-check-actions/semgrep/README.md
@@ -1,0 +1,49 @@
+# Semgrep SAST - Github Action
+
+This action uses Semgrep CI command to scan all supported platforms on a specified scan path
+
+
+The action runs the following:
+- Self detects config rules from semgrep registry
+
+## User tracking
+
+Currently, these repos are using this action:
+
+[]
+
+## Example usage
+
+```yaml
+uses: public-shared-actions/code-check-actions/semgrep@main
+
+```
+
+## Detailed example
+
+```yaml
+name: Semgrep SAST checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-semgrep-sast:
+    permissions:
+      # required for all workflows
+      security-events: write
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+    runs-on: ubuntu-latest
+    name: Semgrep SAST checks
+    steps:
+      - uses: actions/checkout@v3
+      - id: sast_check
+        uses: Kong/public-shared-actions/code-check-actions/semgrep@main
+```

--- a/code-check-actions/semgrep/action.yml
+++ b/code-check-actions/semgrep/action.yml
@@ -1,0 +1,42 @@
+name:  Semgrep SAST
+description: Semgrep SAST
+author: 'Kong'
+inputs:
+  additional_config:
+    description: 'Provide additional config to semgrep ci command using --config'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+
+    - name: SAST Scan
+      uses: docker://returntocorp/semgrep
+      continue-on-error: true
+      with:
+        args: "semgrep ci --config auto --sarif -o semgrep_${{github.sha}}.sarif --suppress-errors --no-autofix ${{ inputs.additional_config }}"
+    
+    # Upload grype cve reports
+    - name: Upload Semgrep SARIF to Workflow
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: semgrep_sast.zip
+        path: |
+          semgrep_${{github.sha}}.sarif
+        if-no-files-found: warn
+
+    - name: Upload SARIF to Github Security
+      if: ${{ always() && github.event.repository.visibility == 'public' }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: semgrep_${{github.sha}}.sarif
+        # Optional category for the results
+        # Used to differentiate multiple results for one commit
+        category: sast_semgrep
+    
+    - name: Print SAST results - SARIF
+      shell: bash
+      run: |
+        cat semgrep_${{github.sha}}.sarif


### PR DESCRIPTION
- Shared action for `Rust` Lint and SCA **only on directory path**:
   - Report Grype CVE SCA results to `GitHub CodeQL security` for `public` repositories 
   - Report Grype CVE SCA results to `workflow artifact` and `console log` for `private` repositories
   - Report Rust Clippy Linting results as `GitHub PR annotations` and `GitHub status check`

- Shared action for `Lua check` Lint and SCA 
   - Report Lua check results as `GitHub PR comment` and `Github status check` using Junit XML
   - SCA: No support yet

- Shared `SEMGREP` action for `SAST` across `all supported languages
   - Auto-detect languages for the repository while scanning
   - Optional additional config ruleset can be provided as input
   -  Report Semgrep SAST results as `PR comments` and `GitHub status check` for private repositories
   -  Report Semgrep SAST results to `GitHub CodeQL security` for `public` repositories


**Known limitations:**
- GitHub Code scanning Alerts reported by Grype SCA Code scanning check are **available** only in `Security -> Github Code Scanning -> filter using pr:<number>` and **not on the PR check summary**
- `Luacheck` and `Rust clippy` [Github check results are associated with the wrong workflow](https://github.com/EnricoMi/publish-unit-test-result-action/issues/181) instead of the actually specified workflow from where the steps are run

POC example:
https://github.com/Scimia/atc-router/pull/4
https://github.com/Scimia/atc-router/security/code-scanning?query=is%3Aopen+pr%3A4