### PR TITLE
fix: use input string instead of boolean

### DIFF
--- a/.github/workflows/build-sdk-js.yml
+++ b/.github/workflows/build-sdk-js.yml
@@ -25,7 +25,7 @@ jobs:
           path: ${{github.workspace}}/sdk
       - uses: ./code-build-actions/build-js-sdk
         with:
-          dry-run: true
+          dry-run: 'true'
           app_directory: ${{ github.workspace }}
           sdk_output_directory: ${{github.workspace}}/sdk
           token: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # public-shared-actions
 Shared actions available to both public and private repositories
+
+## Usage
+  
+  ```yaml
+  - uses: Kong/public-shared-actions/<action-name>@<tag>
+  ```
+  
+  For example:
+  
+  ```yaml
+  - uses:  Kong/public-shared-actions/code-build-actions/build-js-sdk@v1.6.0
+  ```
+  
+  

--- a/code-build-actions/build-js-sdk/README.md
+++ b/code-build-actions/build-js-sdk/README.md
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build JS SDK
-        uses: Kong/public-shared-actions/build-js-sdk@main
+        uses: Kong/public-shared-actions/code-build-actions/build-js-sdk
   
 ```
 

--- a/code-build-actions/build-js-sdk/action.yaml
+++ b/code-build-actions/build-js-sdk/action.yaml
@@ -58,7 +58,7 @@ runs:
         rm -rf openapitools.json templates-js .openapi-generator-ignore .openapi-generator git_push.sh
     - name: Commit SDK changes to the PR
       uses: EndBug/add-and-commit@v9
-      if: ${{ inputs.dry-run != 'false' }}
+      if: ${{ inputs.dry-run != 'true' }}
       with:
         cwd: ${{inputs.sdk_output_directory}}
         add: src

--- a/code-build-actions/build-js-sdk/action.yaml
+++ b/code-build-actions/build-js-sdk/action.yaml
@@ -5,7 +5,7 @@ inputs:
   dry-run:
     description: 'If true, the action will not push the changes to the PR'
     required: false
-    default: false
+    default: 'false'
   token:
     description: 'A Github Token'
     required: true
@@ -58,7 +58,7 @@ runs:
         rm -rf openapitools.json templates-js .openapi-generator-ignore .openapi-generator git_push.sh
     - name: Commit SDK changes to the PR
       uses: EndBug/add-and-commit@v9
-      if: ${{ !inputs.dry-run }}
+      if: ${{ !contains(inputs.dry-run, 'false') }}
       with:
         cwd: ${{inputs.sdk_output_directory}}
         add: src

--- a/code-build-actions/build-js-sdk/action.yaml
+++ b/code-build-actions/build-js-sdk/action.yaml
@@ -58,7 +58,7 @@ runs:
         rm -rf openapitools.json templates-js .openapi-generator-ignore .openapi-generator git_push.sh
     - name: Commit SDK changes to the PR
       uses: EndBug/add-and-commit@v9
-      if: ${{ !contains(inputs.dry-run, 'false') }}
+      if: ${{ inputs.dry-run != 'false' }}
       with:
         cwd: ${{inputs.sdk_output_directory}}
         add: src


### PR DESCRIPTION
This was a bug that led to "dry-run: false" to be ignored.