### PR TITLE
fix(lint): do not specify global standard in luacheck command line arguments

### DIFF
--- a/code-check-actions/lua-lint/action.yml
+++ b/code-check-actions/lua-lint/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'List of files, directories and rockspecs to check'
     required: false
     default: '.' # Scans workspace dir
-    
+
 runs:
   using: composite
   steps:
@@ -19,8 +19,8 @@ runs:
       uses: lunarmodules/luacheck@fcbdeacad00e643e0d78c56b9ba6d8b3c7fa584f
       continue-on-error: true
       with:
-        args: "${{ inputs.additional_args }} -c --codes --ranges --formatter JUnit -q ${{ inputs.files }} > luacheck_${{github.sha}}.xml"
-    
+        args: "${{ inputs.additional_args }} --codes --ranges --formatter JUnit -q ${{ inputs.files }} > luacheck_${{github.sha}}.xml"
+
     - name: Upload results to workflow
       if: always()
       uses: actions/upload-artifact@v3
@@ -32,7 +32,7 @@ runs:
 
 #     - name: Print Luacheck results
 #       shell: bash
-#       run: | 
+#       run: |
 #         cat luacheck_${{github.sha}}.xml
 
     # when using the regular GITHUB_TOKEN, the check-run created by this step will be assigned to a
@@ -51,4 +51,4 @@ runs:
         action_fail: false
         fail_on: 'nothing' # Explicitly don't fail reporting check based on test results
 
-  
+


### PR DESCRIPTION
## Summary

This PR removes the global standard `-c/--compat` which means `--std max` in the luacheck command line argument list.

Having this argument defined will let luacheck ignore what defines in the luacheck rc configuration file, or other `--std` command line argument defined in `additional_args`. This problem currently breaks in any kong-ee PR's lint check(for example, https://github.com/Kong/kong-ee/pull/6283, https://github.com/Kong/kong-ee/pull/6267)

Removing this command line argument can fix the problems occurred in the repos that have customized luacheck rules defined in `luacheckrc`, and also does not influence the repos that not have standard defined, because luacheck's default standard is also `max`.

Ref: https://luacheck.readthedocs.io/en/stable/cli.html#command-line-options
