### PR TITLE
fix: do not attempt to proceed already removed version [KHCP-7885]

### DIFF
--- a/pr-previews/cleanup/action.yml
+++ b/pr-previews/cleanup/action.yml
@@ -47,6 +47,11 @@ runs:
           echo " "
           echo "$((current++))/${total}"
 
+          if [[ -z "$(echo ${pkgDetails} | jq -r '.versions'|grep ${verToRemove})" ]]; then
+            echo "Version already removed, skip..."
+            continue
+          fi
+
           verDetails=$(npm view "${pkgName}@${verToRemove}" --json)
 
           # validate that the version doesn't belong to open PR


### PR DESCRIPTION
`.time` in package details holds information for altready deleted versions. we need to skip those by doing lookup to `.versions` 
