### PR TITLE
skip  failing check run for dependabot branches during luacheck report publishing

### DIFF
--- a/.github/workflows/lua-lint.yml
+++ b/.github/workflows/lua-lint.yml
@@ -16,6 +16,11 @@ jobs:
     env:
       TEST_REPOSITORY: "${{github.repository_owner}}/atc-router"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
     name: Luacheck code analysis
     steps:
       - uses: actions/checkout@v3

--- a/code-check-actions/lua-lint/action.yml
+++ b/code-check-actions/lua-lint/action.yml
@@ -42,7 +42,7 @@ runs:
     # Publishing: https://github.com/EnricoMi/publish-unit-test-result-action#publishing-test-results
     - name: Luacheck Report
       uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
+      if: always() && github.actor != 'dependabot[bot]'
       with:
         files: |
           luacheck_${{github.sha}}.xml


### PR DESCRIPTION
- skip failing check run creation by dependabot only used while testing the shared action due when publishing lua check test results.
- Downstream repos always skip lua check when the actor is dependabot
- [Fix](https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches) requires creating a separate workflow for publishing test results which can be skipped for testing purposes for dependabot branches
