### PR TITLE
feat: Add optional "config" input to sca syft action

### DIFF
--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -28,6 +28,9 @@ inputs:
   registry_password:
     description: 'docker password to login against private docker registry'
     required: false
+  config:
+    description: 'file path to syft custom configuration'
+    required: false
   fail_build:
     description: 'fail the build if the vulnerability is above the severity cutoff'
     required: false
@@ -81,6 +84,7 @@ runs:
       uses: anchore/sbom-action@v0.15.8
       id: sbom_spdx
       with:
+        config: ${{ inputs.config }}
         image: ${{ steps.meta.outputs.scan_image }}
         registry-username: ${{ inputs.registry_username }}
         registry-password: ${{ inputs.registry_password }}
@@ -97,6 +101,7 @@ runs:
       uses: anchore/sbom-action@v0.15.8
       id: sbom_cyclonedx
       with:
+        config: ${{ inputs.config }}
         image: ${{ steps.meta.outputs.scan_image }}
         registry-username: ${{ inputs.registry_username }}
         registry-password: ${{ inputs.registry_password }}


### PR DESCRIPTION
Syft by default looks for configuration files in the PATH where it is run and needs an explicit path for config in case of Github action runners to pick a custom configuration specified in a checkout scan repository.

Helps to specify overrides / select catalogers / ignore rules / exclude paths as required for tuning.

Refer [Syft custom configuration](https://github.com/anchore/syft?tab=readme-ov-file#configuration) to specify explicit [input](https://github.com/anchore/sbom-action/blob/main/action.yml#L76-L78) for the SBOM action


