### PR TITLE
update docker/login-action to v3.0.0

### DIFF
--- a/security-actions/sign-docker-image/action.yml
+++ b/security-actions/sign-docker-image/action.yml
@@ -71,7 +71,7 @@ runs:
           echo 'EOF' >> $GITHUB_ENV
 
     - name: Login to Container Registry
-      uses: docker/login-action@v2.1.0
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       if: ${{ inputs.registry_username != '' && inputs.registry_password != '' }}
       with:
         username: ${{ inputs.registry_username }}


### PR DESCRIPTION
Current version logs warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: docker/login-action@v2.1.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.