### PR TITLE
ci(deps): bump cosign to v2.2.3 to avoid sigstore TUF invalid key issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,22 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/security-actions/sign-docker-image"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "github-actions"
+      include: "scope"
+    
+  - package-ecosystem: docker
+    directory: "/security-actions/sign-docker-image"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "docker"
+      include: "scope"
   
   - package-ecosystem: "github-actions"
     directory: "/code-check-actions/luacheck"

--- a/security-actions/sign-docker-image/action.yml
+++ b/security-actions/sign-docker-image/action.yml
@@ -45,7 +45,7 @@ runs:
       run: $GITHUB_ACTION_PATH/scripts/cosign-metadata.sh
     
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.1.1
+      uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4
 
     - name: Check install!
       shell: bash


### PR DESCRIPTION
# Issue: 
Failure of build pipelines due to missing dependabot config for sign image action and due to deprecated cosign version 2.2.1.
```
getting signer: getting key from Fulcio: getting CTFE public keys: updating local metadata and targets: error updating to TUF remote mirror: invalid key
```
Ex: 
https://github.com/Kong/kong-ee/actions/runs/8345534028/job/22864504377#step:11:619
https://github.com/slsa-framework/slsa-github-generator/issues/3350
https://github.com/Kong/public-shared-actions/actions/runs/8353600274

# Solution:
Bump cosign installaer to use v2.2.3 cosign