### PR TITLE
feat(sbom): option to publish sbom to tags / GH release assets

### DIFF
--- a/.github/workflows/dir-scan.yml
+++ b/.github/workflows/dir-scan.yml
@@ -31,5 +31,6 @@ jobs:
           id: scan-dir
           uses: ./security-actions/sca
           with:
-            asset_prefix: ${{env.TEST_REPOSITORY}}
+            asset_prefix: test.insomnia
             dir: ${{env.TEST_REPOSITORY}}
+            upload-sbom-release-assets: true

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -63,5 +63,6 @@ jobs:
       id: sbom_action_arm64
       uses: ./security-actions/scan-docker-image
       with:
-        asset_prefix: kong-gateway-dev-linux-arm64
+        asset_prefix: test.kong-gateway-dev-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
+        upload-sbom-release-assets: true

--- a/security-actions/sca/README.md
+++ b/security-actions/sca/README.md
@@ -2,15 +2,15 @@
 
 ## Action implemented
 
-- [SCA](./sca/action.yml) is a unified action for composition analysis. The action produces an SBOM, CVE reports for a given image / directory / file.
+- [SCA](./action.yml) is a unified action for composition analysis. The action produces an SBOM, CVE reports for a given image / directory / file.
   - Tools used:
     - [syft](https://github.com/anchore/syft) generates a Software Bill of Materials (SBOM)
     - [grype](https://github.com/anchore/grype) vulnerability scanner for CVE analysis
 
 ### Scan
 
-- Use [SCA](./sca/action.yml) for directories and files
-- Use [SCAN-DOCKER-IMAGE](./scan-docker-image/action.yml) for docker images
+- Use [SCA](./action.yml) for directories and files
+- Use [SCAN-DOCKER-IMAGE](../scan-docker-image/action.yml) for docker images
 
 #### SBOM Generation Working
 
@@ -36,7 +36,7 @@
 
 - Global parameters can be used for enforcement by centralized team across all repositories.
 
-- These parameters are controlled in the [scan-metadata.sh](./security-actions/sca/scripts/scan-metadata.sh)
+- These parameters are controlled in the [scan-metadata.sh](./scripts/scan-metadata.sh)
 
 - User provided input parameters are exposed to the workflows consuming the shared action
 
@@ -89,6 +89,14 @@
     options:
     - 'true'
     - 'false'
+  upload-sbom-release-assets:
+    description: 'specify to only upload sboms to GH release assets'
+    required: false
+    default: false
+    type: choice
+    options:
+    - 'true'
+    - 'false'
 ```
 
 #### Output specification
@@ -97,9 +105,9 @@
 
 - Generates cve vulnerability analysis report based on the spdx sbom file using *grype*
 
-- Uploads the security assets as workflow artifacts and retained based on repo / org settings
+- Uploads all the generated security assets as workflow artifacts and retained based on repo / org settings
 
-- Allows for publishing github releases with security assets
+- When enabled, publishes only the SBOMs to tags / GH release assets
 
 #### Output parameters
 

--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -25,6 +25,14 @@ inputs:
     options:
     - 'true'
     - 'false'
+  upload-sbom-release-assets:
+    description: 'specify to only upload sboms to GH release assets'
+    required: false
+    default: false
+    type: choice
+    options:
+    - 'true'
+    - 'false'
 
 # Outputs to be consumed by others using this SCA action
 outputs:
@@ -72,7 +80,7 @@ runs:
         artifact-name: ${{ steps.meta.outputs.sbom_spdx_file }}
         output-file: ${{ steps.meta.outputs.sbom_spdx_file }}
         upload-artifact: true
-        upload-release-assets: false
+        upload-release-assets: ${{ inputs.upload-sbom-release-assets }}
         dependency-snapshot: false
 
     - name: Generate CycloneDX SBOM Using Syft
@@ -86,7 +94,7 @@ runs:
         artifact-name: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
         output-file: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
         upload-artifact: true
-        upload-release-assets: false
+        upload-release-assets: ${{ inputs.upload-sbom-release-assets }}
         dependency-snapshot: false
 
     - name: Check SBOM files existence

--- a/security-actions/scan-docker-image/README.md
+++ b/security-actions/scan-docker-image/README.md
@@ -2,7 +2,7 @@
 
 ## Action implemented
 
-- [Scan Docker Image](./scan-docker-image/action.yml) is a action for container SCA image scanning and CIS benchmarks. The action produces an SBOM, CVE, and CIS benchmark scanning and reports for a given image.
+- [Scan Docker Image](./action.yml) is a action for container SCA image scanning and CIS benchmarks. The action produces an SBOM, CVE, and CIS benchmark scanning and reports for a given image.
   - Tools used:
     - [syft](https://github.com/anchore/syft) generates a Software Bill of Materials (SBOM)
     - [grype](https://github.com/anchore/grype) vulnerability scanner for container images
@@ -10,7 +10,7 @@
 
 ### Scan Docker Image
 
-- Use [SCAN-DOCKER-IMAGE](./scan-docker-image/action.yml) for docker images
+- Use [SCAN-DOCKER-IMAGE](./action.yml) for docker images
 
 #### SBOM Generation Working
 
@@ -36,7 +36,7 @@
 
 - Global parameters can be used for enforcement by centralized team across all repositories.
 
-- These parameters are controlled in the [scan-metadata.sh](./security-actions/sca/scripts/scan-metadata.sh)
+- These parameters are controlled in the [scan-metadata.sh](./scripts/scan-metadata.sh)
 
 - User provided input parameters are exposed to the workflows consuming the shared action
 
@@ -97,6 +97,14 @@
     options:
     - 'true'
     - 'false'
+  upload-sbom-release-assets:
+    description: 'specify to only upload sboms to GH release assets'
+    required: false
+    default: false
+    type: choice
+    options:
+    - 'true'
+    - 'false'
 ```
 
 #### Output specification
@@ -107,9 +115,9 @@
 
 - Generates docker-cis analysis report using *trivy*
 
-- Uploads the security assets as workflow artifacts and retained based on repo / org settings
+- Uploads all the generated ecurity assets as workflow artifacts and retained based on repo / org settings
 
-- Allows for publishing github releases with security assets
+- When enabled, publishes only the SBOMs to tags / GH release assets
 
 #### Output parameters
 

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -31,6 +31,14 @@ inputs:
     options:
     - 'true'
     - 'false'
+  upload-sbom-release-assets:
+    description: 'specify to only upload sboms to GH release assets'
+    required: false
+    default: false
+    type: choice
+    options:
+    - 'true'
+    - 'false'
 
 outputs:
   cis-json-report:
@@ -75,7 +83,7 @@ runs:
         artifact-name: ${{ steps.meta.outputs.sbom_spdx_file }}
         output-file: ${{ steps.meta.outputs.sbom_spdx_file }}
         upload-artifact: true
-        upload-release-assets: false
+        upload-release-assets: ${{ inputs.upload-sbom-release-assets }}
         dependency-snapshot: false
 
     - name: Generate CycloneDX SBOM Using Syft
@@ -90,7 +98,7 @@ runs:
         artifact-name: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
         output-file: ${{ steps.meta.outputs.sbom_cyclonedx_file }}
         upload-artifact: true
-        upload-release-assets: false
+        upload-release-assets: ${{ inputs.upload-sbom-release-assets }}
         dependency-snapshot: false
 
     - name: Check SBOM files existence


### PR DESCRIPTION
# Description
1. This PR provides an optional input parameter to **UPLOAD** `SBOM` to existing release assets / tags.
2. This will **NOT UPLOAD** the below assets to GH releases:
     - `CVE / SCA scan report`
     - `Trivy CIS report`

# Testing
Creating a tag / release on this repo, the workflows for images and directory scans should upload a `test.*.sbom.*` assets.
