### PR TITLE
Reuse grype db cache during multiple invocations to reduce build time

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -9,6 +9,7 @@ on:
     - main
     tags:
     - '*'
+  workflow_dispatch:
 
 jobs:
   test-scan-docker-image:

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -138,6 +138,8 @@ runs:
         fail-build: 'false'
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
 
     - name: Check vulnerability analysis report existence
       uses: andstor/file-existence-action@v3
@@ -183,6 +185,8 @@ runs:
         fail-build: ${{ steps.meta.outputs.global_enforce_build_failure == 'true' && steps.meta.outputs.global_enforce_build_failure || inputs.fail_build }}
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
 
     - name: Check docker OCI tar existence
       if: ${{ steps.meta.outputs.scan_image != '' }}


### PR DESCRIPTION
Add ability to manually run workflow to test for any issues on-demand