### PR TITLE
Avoid Grype DB downloads during subsequent invocations of grype scan-action

### DIFF
--- a/.github/workflows/dir-scan.yml
+++ b/.github/workflows/dir-scan.yml
@@ -9,6 +9,7 @@ on:
     - main
     tags:
     - '*'
+  workflow_dispatch: {}
 
 jobs:
   test-sca-dir:

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -9,7 +9,7 @@ on:
     - main
     tags:
     - '*'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   test-scan-docker-image:

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -9,6 +9,7 @@ on:
     - main
     tags:
     - '*'
+  workflow_dispatch:
 
 jobs:
   test-scan-docker-image:

--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -134,6 +134,8 @@ runs:
         fail-build: 'false'
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
 
     - name: Check vulnerability analysis report existence
       uses: andstor/file-existence-action@v3
@@ -179,3 +181,5 @@ runs:
         fail-build: ${{ steps.meta.outputs.global_enforce_build_failure == 'true' && steps.meta.outputs.global_enforce_build_failure || inputs.fail_build }}
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -138,6 +138,8 @@ runs:
         fail-build: 'false'
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
 
     - name: Check vulnerability analysis report existence
       uses: andstor/file-existence-action@v3
@@ -183,6 +185,8 @@ runs:
         fail-build: ${{ steps.meta.outputs.global_enforce_build_failure == 'true' && steps.meta.outputs.global_enforce_build_failure || inputs.fail_build }}
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
 
     - name: Check docker OCI tar existence
       if: ${{ steps.meta.outputs.scan_image != '' }}

--- a/security-actions/scan-rust/action.yml
+++ b/security-actions/scan-rust/action.yml
@@ -93,3 +93,5 @@ runs:
         output-format: table
         fail-build: ${{ steps.meta.outputs.global_enforce_build_failure == 'true' && steps.meta.outputs.global_enforce_build_failure || inputs.fail_build }}
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+      env:
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above


### PR DESCRIPTION
# Summary
- Grype action caches the db on its first invocation at `cache-dir: "$XDG_CACHE_HOME/grype/db"` as per [config](https://github.com/anchore/grype?tab=readme-ov-file#configuration) file
- Optimize build time by avoiding grype db downloads during multiple subsequent runs of `anchore/scan-action` for CVE analysis. 

# Out of Scope
- This improvement WILL NOT FIX the [read timeout issue](https://github.com/anchore/scan-action/issues/306) during the first invocation of the action 


