### PR TITLE
Bump sbom-action from v.0.15.11 to v0.16.0

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -72,3 +72,23 @@ jobs:
         asset_prefix: test.kong-gateway-dev-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
         upload-sbom-release-assets: true
+
+  test-download-sbom:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    name: Download SBOM
+    runs-on: ubuntu-22.04
+    needs: [test-scan-docker-image]
+    env:
+      SBOM_DOWNLOAD_PATH: ${{ github.workspace }}/security-assets/sboms
+      SPDX_SBOM_PATTERN: "*sbom.spdx.json"
+      CYCLONEDX_SBOM_PATTERN: "*sbom.cyclonedx.json"
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: "Download all SBOM assets"
+        id: collect_sbom
+        if: ${{ needs.test-scan-docker-image.result == 'success' }}
+        run: |-
+          gh run download ${{ github.run_id }} -D ${{ env.SBOM_DOWNLOAD_PATH }} -p '${{ env.CYCLONEDX_SBOM_PATTERN }}' -p '${{ env.SPDX_SBOM_PATTERN }}' --repo ${{ github.repository }}
+      - name: Inspect download assets
+        run: |
+          ls -alR ${{ github.workspace }}/security-assets/sboms

--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -74,7 +74,7 @@ runs:
 
     # Must upload artifact for output file parameter to have effect
     - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.15.11
+      uses: anchore/sbom-action@v0.16.0
       id: sbom_spdx
       with:
         config: ${{ inputs.config }}
@@ -89,7 +89,7 @@ runs:
         github-token: ${{ inputs.github-token }}
 
     - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.15.11
+      uses: anchore/sbom-action@v0.16.0
       id: sbom_cyclonedx
       with:
         config: ${{ inputs.config }}

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -76,7 +76,7 @@ runs:
 
     # Must upload artifact for output file parameter to have effect
     - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.15.11
+      uses: anchore/sbom-action@v0.16.0
       id: sbom_spdx
       with:
         config: ${{ inputs.config }}
@@ -92,7 +92,7 @@ runs:
         github-token: ${{ inputs.github-token }}
 
     - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@v0.15.11
+      uses: anchore/sbom-action@v0.16.0
       id: sbom_cyclonedx
       with:
         config: ${{ inputs.config }}


### PR DESCRIPTION
Fix to download assets during workflow run and compatible with download-artifact@v4
Fixes: https://github.com/anchore/sbom-action/issues/434