### PR TITLE
fix: omitted severity flags in docker image scan action

### DIFF
--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -287,10 +287,9 @@ runs:
       id: cis_json
       with:
         entrypoint: trivy
-        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f json --severity ${{ env.severity }} --ignore-unfixed -o ${{ steps.meta.outputs.cis_json_file }}"
+        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f json --ignore-unfixed -o ${{ steps.meta.outputs.cis_json_file }}"
       env:
         compliance: docker-cis
-        severity: ${{ steps.meta.outputs.global_enforce_build_failure }}
         input: ${{ steps.docker_tar.outputs.files_exists == 'true' && '--input' || '' }}
 
     - name: upload docker-cis JSON report
@@ -307,7 +306,7 @@ runs:
       uses: docker://ghcr.io/aquasecurity/trivy:0.37.2
       with:
         entrypoint: trivy
-        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f table --severity ${{ env.severity }} --ignore-unfixed --exit-code ${{ env.exit-code }}"
+        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f table --ignore-unfixed --exit-code ${{ env.exit-code }}"
       env:
         exit-code: ${{ (steps.meta.outputs.global_enforce_build_failure == 'true' || inputs.fail_build == 'true') && '1' || '0' }}
         compliance: docker-cis

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -310,5 +310,4 @@ runs:
       env:
         exit-code: ${{ (steps.meta.outputs.global_enforce_build_failure == 'true' || inputs.fail_build == 'true') && '1' || '0' }}
         compliance: docker-cis
-        severity: ${{ steps.meta.outputs.global_enforce_build_failure }}
         input: ${{ steps.docker_tar.outputs.files_exists == 'true' && '--input' || '' }}


### PR DESCRIPTION
- Update to Step "Generate docker-cis JSON report", removed severity flag as it was causing warnings "unknown severity option: unknown severity: FALSE"
- Update to Step "Inspect docker-cis report", removed severity flag as it was causing warnings "unknown severity option: unknown severity: FALSE"
- This severity flag is not being used at this point. Trivy uses this flag to restrict the scan to specific severity levels
- Because of no explicit severity flag, shared action uses value of global_enforce_build_failure env defined in our scripts