### PR TITLE
save grype db cache on updates to avoid using stale cache db

### DIFF
--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -121,11 +121,11 @@ runs:
     - name: Download Grype
       uses: anchore/scan-action/download-grype@v4.1.1
     
-    # Check for any existing cache to reuse / update
-    - name: Cache Grype DB
-      id: cache_grype_db
+    # Check for any existing cache to reuse
+    - name: Restore Grype DB Cache
+      id: restore_grype_db
       if: ${{ inputs.force_grype_db_update != 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       env:
         cache-name: cache_grype_db
       with:
@@ -139,7 +139,6 @@ runs:
 
     ## Edgecase: Grype DB will never update if stale cache is found
     - name: Grype DB Check Updates
-      #if: ${{ steps.cache_grype_db.outputs.cache-hit != 'true' }}
       id: grype_db_check_updates
       shell: bash
       run: |
@@ -178,10 +177,10 @@ runs:
         GRYPE_DB_UPDATE_DOWNLOAD_TIMEOUT: 600s # timeout for actual db download if needed
         FORCE_GRYPE_DB_UPDATE: ${{ inputs.force_grype_db_update }}
 
-    - name: Cache Grype DB updates
+    - name: Update Cache / Save Grype DB updates
       if: ${{ steps.grype_db_check_updates.outputs.GRYPE_DB_UPDATE_STATUS == 0 }}
-      id: cache_grype_db_updates
-      uses: actions/cache@v4
+      id: save_grype_db_cache_updates
+      uses: actions/cache/save@v4
       env:
         cache-name: cache_grype_db # Use generic cache key instead of unique keys for different refs since CVE DB doesn't change frequently
       with:


### PR DESCRIPTION
- Fixes the issue to restore old cache when exists
- On DB drift, updates DB
- Save any DB updates back to same cache key and then use it

Issue:
![Screenshot 2024-08-21 at 11 54 53 PM](https://github.com/user-attachments/assets/10afe835-bfc2-47fa-bfef-2ad33f9c6cef)

Cache for main branch before PR is merged is stale (5 days old)
![Screenshot 2024-08-22 at 12 01 18 AM](https://github.com/user-attachments/assets/29747be1-5db6-48d2-9a7c-a7ca17d016fd)

After PR is merged into main branch (Refer to action run after PR is merged for main branch):

