### PR TITLE
SEC-1176 - Option to skip Grype DB caching and tradeoff to use Grype CDN

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -72,8 +72,6 @@ jobs:
         asset_prefix: test.kong-gateway-dev-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
         upload-sbom-release-assets: true
-        skip_grype_db_cache: 'true'
-        force_grype_db_update: 'true'
 
   test-download-sbom:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -72,6 +72,8 @@ jobs:
         asset_prefix: test.kong-gateway-dev-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
         upload-sbom-release-assets: true
+        skip_grype_db_cache: 'true'
+        force_grype_db_update: 'true'
 
   test-download-sbom:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -45,6 +45,14 @@ inputs:
     options:
     - 'true'
     - 'false'
+  skip_grype_db_cache:
+    required: false
+    default: false
+    description: 'Skip the caching of the Grype DB during the SBOM (Software Bill of Materials) scanning process'
+    type: choice
+    options:
+      - 'true'
+      - 'false'
 
 # Outputs to be consumed by others using this SCA action
 outputs:
@@ -120,11 +128,12 @@ runs:
 
     - name: Download Grype
       uses: anchore/scan-action/download-grype@v4.1.1
-    
+
+    # Skip Cache Restoration: If skip_grype_db_cache is true, skip the restoration of the cache.
     # Check for any existing cache to reuse
     - name: Grype DB Cache
       id: grype_db_cache
-      if: ${{ inputs.force_grype_db_update != 'true' }}
+      if: ${{ inputs.skip_grype_db_cache != 'true' && inputs.force_grype_db_update != 'true' }}
       uses: actions/cache@v4
       with:
         # Grype cache files are stored in `~/.cache/grype/db` on Linux/macOS
@@ -183,7 +192,7 @@ runs:
     # Condition helps When this action is invoked more than once in the same workflow
     # Example: first workflow saves cache if updates available and second retries to save again even when latest updated cache is available and fails
     - name: Update Cache / Save Grype DB updates
-      if: ${{ steps.grype_db.outputs.GRYPE_DB_CHECK_UPDATE_STATUS != 0 && steps.grype_db.outputs.GRYPE_DB_UPDATE_STATUS }}
+      if: ${{ inputs.skip_grype_db_cache != 'true' && steps.grype_db.outputs.GRYPE_DB_CHECK_UPDATE_STATUS != 0 && steps.grype_db.outputs.GRYPE_DB_UPDATE_STATUS }}
       id: save_grype_db_cache_updates
       uses: actions/cache/save@v4
       with:

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -51,6 +51,14 @@ inputs:
     options:
     - 'true'
     - 'false'
+  skip_grype_db_cache:
+    required: false
+    default: false
+    description: 'Skip grype db caching'
+    type: choice
+    options:
+      - 'true'
+      - 'false'
 
 outputs:
   cis-json-report:
@@ -125,10 +133,11 @@ runs:
     - name: Download Grype
       uses: anchore/scan-action/download-grype@v4.1.1
 
+    # Skip Cache Restoration: If skip_grype_db_cache is true, skip the restoration of the cache.
     # Check for any existing cache to reuse
     - name: Grype DB Cache
       id: grype_db_cache
-      if: ${{ inputs.force_grype_db_update != 'true' }}
+      if: ${{ inputs.skip_grype_db_cache != 'true' && inputs.force_grype_db_update != 'true' }}
       uses: actions/cache@v4
       with:
         # Grype cache files are stored in `~/.cache/grype/db` on Linux/macOS
@@ -186,8 +195,9 @@ runs:
     # Save cache when db update is available (i.e drift) and update is successful
     # Condition helps When this action is invoked more than once in the same workflow
     # Example: first workflow saves cache if updates available and second retries to save again even when latest updated cache is available and fails
+    # Skip Cache Saving: If skip_grype_db_cache is true, skip saving the cache updates.
     - name: Update Cache / Save Grype DB updates
-      if: ${{ steps.grype_db.outputs.GRYPE_DB_CHECK_UPDATE_STATUS != 0 && steps.grype_db.outputs.GRYPE_DB_UPDATE_STATUS }}
+      if: ${{ inputs.skip_grype_db_cache != 'true' && steps.grype_db.outputs.GRYPE_DB_CHECK_UPDATE_STATUS != 0 && steps.grype_db.outputs.GRYPE_DB_UPDATE_STATUS }}
       id: save_grype_db_cache_updates
       uses: actions/cache/save@v4
       with:


### PR DESCRIPTION
## PR Description:
**Summary:**
This PR introduces a new input parameter `skip_grype_db_cache` to the sca/scan-docker-image action. This option allows users to skip the caching of the Grype DB during the SBOM (Software Bill of Materials) scanning process. By setting this input to `true`, both the restoration of existing caches and the saving of new cache updates will be bypassed.

## Changes:
- Added a `skip_grype_db_cache` input parameter to the action.
   - Type: `choice`
   - Options:`true`, `false`
   - Default: `false`
- Updated the workflow logic to conditionally skip the Grype DB caching steps based on the value of `skip_grype_db_cache`.
   - When `skip_grype_db_cache` is set to `true`, the action will:
       - Skip restoring any existing Grype DB cache.
       - Skip saving any updates to the Grype DB cache.
       
       
## Usage:
To trigger the skip cache behavior, set `skip_grype_db_cache` to `true` in the workflow file when invoking the scan-docker-image action:
```
    - name: Scan ARM64 Image digest
      if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
      id: sbom_action_arm64
      uses: ./security-actions/scan-docker-image
      with:
        asset_prefix: test.kong-gateway-dev-linux-arm64
        image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
        upload-sbom-release-assets: true
        skip_grype_db_cache: 'true'
```

## Why this is needed
### Issue:
Github doesn't provide a way to save / overwrite same cache key.
Refer https://github.com/Kong/public-shared-actions/pull/147 for errors encountered trying to update same cache key when multiple workflows / jobs are trying to access it.

### Workaround:
[ unique short-term cache keys ](https://github.com/actions/cache/blob/main/caching-strategies.md#creating-a-short-lived-cache) can be used across multiple workflows.

This approach generates grype db cache (~ 150mb) using cache key `cache_grype_<github.run_id>-<github..run_attempt>` to save cache without having to override same cache key across multiple jobs / workflows

### Side effect / Consequence resulting from workaround:
However ; the workaround can result in a lot of short term unique caches. This can quickly hit cache limit of 10GB. Github however rotates unused cache in 7 days.
![Screenshot 2024-08-22 at 2 16 20 AM](https://github.com/user-attachments/assets/78589eaa-96f8-466e-a9a7-b629d836e6cf)


### Workaround / Alternative tradeoff:
- Option 1: an input parameter to skip caching grype db completely and rely on making the network calls to external CDN. 
- Option 2: - Downstream applications can include a workflow as described to[ delete caches when a PR branch is closed.](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries) 
-
### Conclusion:
Make tradeoff between 
- external network call and up-to-date Grype DB from their CDN as per this [post] (https://anchorecommunity.discourse.group/t/grype-vulnerability-database-hosting-update/75) 
VS 
- caching using unique keys more for more availability at the cost of GH cache space limits and [deleting caches when a PR branch is closed.](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries) 

