### PR TITLE
Defaulting to use grype cdn and skip cache by default

### DIFF
--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -47,9 +47,9 @@ inputs:
     - 'false'
   skip_grype_db_cache:
     required: false
-    default: false
+    default: true
     description: 'Skip the caching of the Grype DB during the SBOM (Software Bill of Materials) scanning process'
-    type: choice
+    type: 'choice'
     options:
       - 'true'
       - 'false'

--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -49,7 +49,7 @@ inputs:
     required: false
     default: true
     description: 'Skip the caching of the Grype DB during the SBOM (Software Bill of Materials) scanning process'
-    type: 'choice'
+    type: choice
     options:
       - 'true'
       - 'false'

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -53,7 +53,7 @@ inputs:
     - 'false'
   skip_grype_db_cache:
     required: false
-    default: false
+    default: true
     description: 'Skip grype db caching'
     type: choice
     options:
@@ -219,7 +219,7 @@ runs:
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
       env:
-        GRYPE_DB_AUTO_UPDATE: false 
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db pointed from grype_db step above
 
     # Don't fail during report generation
     # JSON format will report  any ignored rules
@@ -234,7 +234,7 @@ runs:
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
       env:
-        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db pointed from grype_db step above
 
     - name: Check vulnerability analysis report existence
       if: ${{ steps.grype_db_check_updates.outputs.GRYPE_DB_UPDATE_STATUS == 0 }} # Run only if DB is available on the runner
@@ -285,7 +285,7 @@ runs:
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
       env:
-        GRYPE_DB_AUTO_UPDATE: false # Use grype db cache from grype step above
+        GRYPE_DB_AUTO_UPDATE: false # Use grype db pointed from grype_db step above
 
     - name: Check docker OCI tar existence
       if: ${{ steps.meta.outputs.scan_image != '' }}


### PR DESCRIPTION
only use cache during cdn failures and set explicitly

# Cause
- Refer https://github.com/Kong/public-shared-actions/issues/151
- Grype has updated their CDN which seems NOT flaky as per https://anchorecommunity.discourse.group/t/grype-vulnerability-database-hosting-update/75

# Targets:
Uses option 1 to skip cache and default to CDN until the issue is fixed and grype CDN is flaky again