### PR TITLE
feat(SEC-1211): update semgrep version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,11 @@ updates:
     commit-message:
       prefix: "github-actions"
       include: "scope"
+
+  - package-ecosystem: docker
+    directory: "/security-actions/semgrep"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "semgrep"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,11 +73,3 @@ updates:
     commit-message:
       prefix: "github-actions"
       include: "scope"
-
-  - package-ecosystem: docker
-    directory: "/security-actions/semgrep"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "semgrep"
-      include: "scope"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,7 +25,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
         with:
           repository: ${{env.TEST_REPOSITORY}}
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,6 +25,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: ${{env.TEST_REPOSITORY}}
           token: ${{secrets.GITHUB_TOKEN}}

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
 
     - name: SAST Scan
-      uses: returntocorp/semgrep:latest
+      uses: docker://returntocorp/semgrep
       id: semgrep
       continue-on-error: true
       with:

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -24,16 +24,14 @@ inputs:
     - 'false'
 runs:
   using: 'composite'
-  container:
-    # Use the official Semgrep Docker image
-    image: semgrep/semgrep
-
   steps:
 
     - name: SAST Scan
+      uses: docker://returntocorp/semgrep:1.86.0
       id: semgrep
-      run: semgrep ci --config auto --sarif -o semgrep_${{github.sha}}.sarif --no-autofix ${{ inputs.additional_config }}
       continue-on-error: true
+      with:
+        args: "semgrep ci --config auto --sarif -o semgrep_${{github.sha}}.sarif --no-autofix ${{ inputs.additional_config }}"
 
     # Upload grype cve reports
     - name: Upload Semgrep SARIF to Workflow

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -24,15 +24,17 @@ inputs:
     - 'false'
 runs:
   using: 'composite'
+  container:
+    # Use the official Semgrep Docker image
+    image: semgrep/semgrep
+
   steps:
 
     - name: SAST Scan
-      uses: returntocorp/semgrep:1.86.0
       id: semgrep
+      run: semgrep ci --config auto --sarif -o semgrep_${{github.sha}}.sarif --no-autofix ${{ inputs.additional_config }}
       continue-on-error: true
-      with:
-        args: "semgrep ci --config auto --sarif -o semgrep_${{github.sha}}.sarif --no-autofix ${{ inputs.additional_config }}"
-    
+
     # Upload grype cve reports
     - name: Upload Semgrep SARIF to Workflow
       if: always()

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
 
     - name: SAST Scan
-      uses: docker://returntocorp/semgrep
+      uses: docker://returntocorp/semgrep:1.86.0
       id: semgrep
       continue-on-error: true
       with:

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
 
     - name: SAST Scan
-      uses: docker://returntocorp/semgrep:1.86.0
+      uses: returntocorp/semgrep
       id: semgrep
       continue-on-error: true
       with:

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
 
     - name: SAST Scan
-      uses: returntocorp/semgrep
+      uses: returntocorp/semgrep:latest
       id: semgrep
       continue-on-error: true
       with:

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
 
     - name: SAST Scan
-      uses: docker://returntocorp/semgrep
+      uses: returntocorp/semgrep:1.86.0
       id: semgrep
       continue-on-error: true
       with:


### PR DESCRIPTION
Why to update?
Semgrep is giving following message in the scan runs `A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading` 

Note:
We use latest version tag of the image but looks like semgrep has made few new tag releases but have not rolled out their `Latest` tag to the latest version that is `1.86.0`

