### PR TITLE
fix: success not status

### DIFF
--- a/slack-actions/workflow-notification/action.yaml
+++ b/slack-actions/workflow-notification/action.yaml
@@ -59,7 +59,7 @@ runs:
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "${{ inputs.status == 'failure' && inputs.failure-message || inputs.status-message }}"
+                "text": "${{ inputs.status == 'failure' && inputs.failure-message || inputs.success-message }}"
               }
             },
             {


### PR DESCRIPTION
Fix `input.status-message` should be `input-success-message`

Apparently I can't code on Friday