### PR TITLE
feat(slack): new workflow inputs

### DIFF
--- a/.github/workflows/test-slack-actions.yaml
+++ b/.github/workflows/test-slack-actions.yaml
@@ -1,0 +1,66 @@
+name: Test Slack Workflow Notifications
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+jobs:
+  test-slack-workflow-notifications:
+    runs-on: ubuntu-latest
+    name: Test slack-actions/workflow-notifications
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Post 'success' notification
+        uses: ./slack-actions/workflow-notification
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFY_SLACK_NOTIFICATION_TEST }}
+          status: 'success'
+          success-message: ":test_tube: [TEST]: This is a test *success* notification from `Kong/public-shared-actions`"
+
+      - name: Post 'failure' notification
+        uses: ./slack-actions/workflow-notification
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_ALERT_SLACK_NOTIFICATION_TEST }}
+          status: 'failure'
+          failure-message: ":test_tube: [TEST]: This is a test *failure* notification from `Kong/public-shared-actions`"
+
+      - name: Post 'success' notification with custom payload
+        uses: ./slack-actions/workflow-notification
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFY_SLACK_NOTIFICATION_TEST }}
+          status: 'success'
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "[TEST] Kong/public-shared-actions",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ":test_tube:"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "This is a test notification with a *custom payload*."
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/test-slack-actions.yaml
+++ b/.github/workflows/test-slack-actions.yaml
@@ -33,6 +33,18 @@ jobs:
           status: 'failure'
           failure-message: ":test_tube: [TEST]: This is a test *failure* notification from `Kong/public-shared-actions`"
 
+      - name: Post 'cancelled' notification
+        uses: ./slack-actions/workflow-notification
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_ALERT_SLACK_NOTIFICATION_TEST }}
+          status: 'cancelled'
+
+      - name: Post 'skipped' notification
+        uses: ./slack-actions/workflow-notification
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_ALERT_SLACK_NOTIFICATION_TEST }}
+          status: 'skipped'
+
       - name: Post 'success' notification with custom payload
         uses: ./slack-actions/workflow-notification
         with:

--- a/slack-actions/workflow-notification/action.yaml
+++ b/slack-actions/workflow-notification/action.yaml
@@ -6,20 +6,32 @@ inputs:
     description: The Slack webhook URL.
     required: true
   status:
-    description: The status of the workflow, one of "success" or "failure".
+    description: The status of the workflow. One of 'success', 'failure', 'cancelled', or 'skipped'.
     required: true
   # OPTIONAL INPUTS
+  payload:
+    description: The Slack Block Kit JSON payload to send to Slack. If provided, this input will override all other inputs other than `slack-webhook-url`. https://app.slack.com/block-kit-builder
+    required: false
+    default: ''
   header:
     description: The notification header, as a plain text string. Defaults to the workflow name.
     required: false
   success-message:
     description: The message to display when the workflow is successful. Accepts markdown syntax.
     required: false
-    default: ":large_green_circle: Workflow completed successfully :mario_luigi_dance:"
+    default: ':large_green_circle: Workflow completed successfully :mario_luigi_dance:'
   failure-message:
     description: The message to display when the workflow is successful. Accepts markdown syntax.
     required: false
-    default: ":red_circle: Workflow failed :sad-panda:"
+    default: ':red_circle: Workflow failed :sad-panda:'
+  cancelled-message:
+    description: The message to display when the workflow is cancelled. Accepts markdown syntax.
+    required: false
+    default: ':black_circle: Workflow cancelled'
+  skipped-message:
+    description: The message to display when the workflow is skipped. Accepts markdown syntax.
+    required: false
+    default: ':white_circle: Workflow skipped'
 
 runs:
   using: composite
@@ -32,16 +44,33 @@ runs:
         fallbackBranchName=$(echo "${{ github.ref }}" | cut -c12-)
         shortCommitHash=$(echo "${{ github.sha }}" | cut -c1-7)
 
+        # Determine status message
+        if [[ "${{ inputs.status }}" == 'success' ]]; then
+          statusMessage=$(echo "${{ inputs.success-message }}")
+        elif [[ "${{ inputs.status }}" == 'failure' ]]; then
+          statusMessage=$(echo "${{ inputs.failure-message }}")
+        elif [[ "${{ inputs.status }}" == 'cancelled' ]]; then
+          statusMessage=$(echo "${{ inputs.cancelled-message }}")
+        elif [[ "${{ inputs.status }}" == 'skipped' ]]; then
+          statusMessage=$(echo "${{ inputs.skipped-message }}")
+        else
+          echo "Invalid workflow status: ${{ inputs.status }}"
+          exit 1
+        fi
+
         # Output All Variables
         echo "fallback-branch-name=${fallbackBranchName}" >> $GITHUB_OUTPUT
         echo "short-commit-hash=${shortCommitHash}" >> $GITHUB_OUTPUT
+        echo "status-message=${statusMessage}" >> $GITHUB_OUTPUT
 
         # Echo all variables for debugging
         echo "fallback-branch-name=${fallbackBranchName}"
         echo "short-commit-hash=${shortCommitHash}"
+        echo "status-message=${statusMessage}"
 
     - name: Construct Slack payload
       id: slack-payload
+      if: ${{ inputs.payload == '' }}
       shell: bash
       run: |
         PAYLOAD=$(cat << EOF
@@ -59,7 +88,7 @@ runs:
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "${{ inputs.status == 'failure' && inputs.failure-message || inputs.success-message }}"
+                "text": "${{ steps.slack-variables.outputs.status-message }}"
               }
             },
             {
@@ -94,7 +123,7 @@ runs:
                   "text": {
                     "type": "plain_text",
                     "emoji": true,
-                    "text": "${{ inputs.status == 'failure' && 'View failed run' || 'View successful run' }}"
+                    "text": "${{ inputs.status == 'failure' && 'View failed run' || 'View workflow run' }}"
                   }
                 }
               ]
@@ -113,4 +142,4 @@ runs:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
         SLACK_WEBHOOK_TYPE: 'INCOMING_WEBHOOK'
       with:
-        payload: ${{ steps.slack-payload.outputs.payload }}
+        payload: ${{ inputs.payload != '' && inputs.payload || steps.slack-payload.outputs.payload }}


### PR DESCRIPTION
# Summary

Add support for custom payloads and additional 'status' values.

## Additional Statuses and messages 

`inputs.status` now accepts any one of: `success`, `failure`, `cancelled`, or `skipped` which correspond to the related `{status}-message` inputs.

## Custom Payload

You can set the `payload` input with content via [Slack Block Kit Builder](https://app.slack.com/block-kit-builder/) that will override the `header` `*-message` and other inputs to customize your notification.

```yaml
- name: Post 'success' notification with custom payload
  uses: ./slack-actions/workflow-notification
  with:
    slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFY_SLACK_NOTIFICATION_TEST }}
    status: 'success'
    payload: |
      {
        "blocks": [
          {
            "type": "header",
            "text": {
              "type": "plain_text",
              "text": "[TEST] Kong/public-shared-actions",
              "emoji": true
            }
          },
          {
            "type": "context",
            "elements": [
              {
                "type": "mrkdwn",
                "text": ":test_tube:"
              },
              {
                "type": "mrkdwn",
                "text": "This is a test notification with a *custom payload*."
              }
            ]
          }
        ]
      }
```

## Added tests

Examples:

- [success](https://kongstrong.slack.com/archives/C03MNDB47AL/p1727716905185859)
- [failure](https://kongstrong.slack.com/archives/C03LVNEGGP7/p1727716905635349)
- [custom payload](https://kongstrong.slack.com/archives/C03MNDB47AL/p1727716906162759)