### PR TITLE
chore(deps): bump github/codeql-action/upload-sarif from v2 to v3

### DIFF
--- a/security-actions/scan-rust/action.yml
+++ b/security-actions/scan-rust/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Publish SARIF to github code scanning
       if: ${{ always() && inputs.codeql_upload == 'true' && github.event.repository.visibility == 'public' }}
       continue-on-error: true
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}
         category: sca_rust

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Upload SARIF to Github Code Scanning
       if: ${{ always() && inputs.codeql_upload == 'true' && github.event.repository.visibility == 'public' }}
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: semgrep_${{github.sha}}.sarif


### PR DESCRIPTION
no longer depends on versions below Node.js 20.

KAG-5461