### PR TITLE
feat(security-actions/scan-docker-image): support `trivy_db_cache` as alternate

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -65,7 +65,6 @@ jobs:
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
         skip_cis_scan: false
         trivy_db_cache: Kong/trivy-db-mirror@master
-        trivy_db_cache_token: ${{ secrets.PAT }}
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         asset_prefix: kong-gateway-dev-linux-amd64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
-        skip_cis_scan: true
+        skip_cis_scan: false
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
@@ -73,7 +73,7 @@ jobs:
         asset_prefix: test.kong-gateway-dev-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
         upload-sbom-release-assets: true
-        skip_cis_scan: true
+        skip_cis_scan: false
 
   test-download-sbom:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -64,6 +64,8 @@ jobs:
         asset_prefix: kong-gateway-dev-linux-amd64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
         skip_cis_scan: false
+        trivy_db_cache: Kong/trivy-db-mirror@master
+        trivy_db_cache_token: ${{ secrets.PAT }}
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -65,6 +65,7 @@ jobs:
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
         skip_cis_scan: false
         trivy_db_cache: Kong/trivy-db-mirror@master
+        trivy_db_cache_token: ${{ secrets.PAT }}
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -322,18 +322,9 @@ runs:
       # Discussion: https://github.com/aquasecurity/trivy/discussions/7668
       # Fix: Refer https://github.com/aquasecurity/trivy/discussions/7951 usign mirror.gcr.io 
     - name: Install Trivy
-      if: inputs.skip_cis_scan != 'true'
       shell: bash
       run: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.57.1
-    
-    - name: Generate kong bot app token
-      id: github-app-token
-      if: inputs.trivy_db_cache != ''
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      with:
-        app_id: ${{ vars.KONG_GH_APP_ID }}
-        private_key: ${{ secrets.KONG_GH_APP_PRIVATE_KEY }}
 
     - name: Checkout Trivy DB cache
       if: inputs.trivy_db_cache != ''
@@ -342,7 +333,7 @@ runs:
         repository: ${{ steps.parse_cache.outputs.repository }}
         ref: ${{ steps.parse_cache.outputs.ref }}
         path: trivy-db-cache
-        token: ${{ steps.github-app-token.outputs.token || inputs.trivy_db_cache_token }}
+        token: ${{ inputs.trivy_db_cache_token }}
 
     - name: Setup Trivy DB from cache
       if: inputs.trivy_db_cache != ''

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -322,9 +322,18 @@ runs:
       # Discussion: https://github.com/aquasecurity/trivy/discussions/7668
       # Fix: Refer https://github.com/aquasecurity/trivy/discussions/7951 usign mirror.gcr.io 
     - name: Install Trivy
+      if: inputs.skip_cis_scan != 'true'
       shell: bash
       run: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.57.1
+    
+    - name: Generate kong bot app token
+      id: github-app-token
+      if: inputs.trivy_db_cache != ''
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ vars.KONG_GH_APP_ID }}
+        private_key: ${{ secrets.KONG_GH_APP_PRIVATE_KEY }}
 
     - name: Checkout Trivy DB cache
       if: inputs.trivy_db_cache != ''
@@ -333,7 +342,7 @@ runs:
         repository: ${{ steps.parse_cache.outputs.repository }}
         ref: ${{ steps.parse_cache.outputs.ref }}
         path: trivy-db-cache
-        token: ${{ inputs.trivy_db_cache_token }}
+        token: ${{ steps.github-app-token.outputs.token || inputs.trivy_db_cache_token }}
 
     - name: Setup Trivy DB from cache
       if: inputs.trivy_db_cache != ''

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -318,10 +318,13 @@ runs:
         echo "repository=${REPO}" >> $GITHUB_OUTPUT
         echo "ref=${REF}" >> $GITHUB_OUTPUT
 
+      # Issue: https://github.com/aquasecurity/trivy/issues/7938
+      # Discussion: https://github.com/aquasecurity/trivy/discussions/7668
+      # Fix: Refer https://github.com/aquasecurity/trivy/discussions/7951 usign mirror.gcr.io 
     - name: Install Trivy
       shell: bash
       run: |
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.55.2
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.57.1
 
     - name: Checkout Trivy DB cache
       if: inputs.trivy_db_cache != ''
@@ -345,6 +348,8 @@ runs:
         cd ..
         rm -rf trivy-db-cache
 
+    # Issue: https://github.com/aquasecurity/trivy/issues/7938
+    # Fix: Refer https://github.com/aquasecurity/trivy/discussions/7951 usign mirror.gcr.io 
     - name: Generate docker-cis JSON report
       if: ${{ inputs.skip_cis_scan != 'true' && steps.meta.outputs.scan_image != '' }}
       id: cis_json

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -67,6 +67,12 @@ inputs:
     options:
       - 'true'
       - 'false'
+  trivy_db_cache:
+    description: 'GitHub repository containing Trivy DB cache (format: owner/repo@ref). Database should be named `db.tar.gz` on the default branch.'
+    required: false
+  trivy_db_cache_token:
+    description: 'Token for accessing `trivy_db_cache`.'
+    required: false
 
 outputs:
   cis-json-report:
@@ -302,13 +308,55 @@ runs:
       with:
         files: "${{ steps.meta.outputs.scan_image }}"
 
+    - name: Parse Trivy DB cache input
+      if: inputs.trivy_db_cache != ''
+      shell: bash
+      id: parse_cache
+      run: |
+        REPO=$(echo "${{ inputs.trivy_db_cache }}" | cut -d'@' -f1)
+        REF=$(echo "${{ inputs.trivy_db_cache }}" | cut -d'@' -f2)
+        echo "repository=${REPO}" >> $GITHUB_OUTPUT
+        echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+    - name: Install Trivy
+      shell: bash
+      run: |
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.55.2
+
+    - name: Checkout Trivy DB cache
+      if: inputs.trivy_db_cache != ''
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ steps.parse_cache.outputs.repository }}
+        ref: ${{ steps.parse_cache.outputs.ref }}
+        path: trivy-db-cache
+        token: ${{ inputs.trivy_db_cache_token }}
+
+    - name: Setup Trivy DB from cache
+      if: inputs.trivy_db_cache != ''
+      shell: bash
+      run: |
+        # Create Trivy cache directory
+        mkdir -p ~/.cache/trivy/db
+        
+        # Extract the DB
+        cd trivy-db-cache
+        tar -xvf db.tar.gz -C ~/.cache/trivy/db
+        cd ..
+        rm -rf trivy-db-cache
+
     - name: Generate docker-cis JSON report
-      uses: docker://aquasec/trivy:0.55.2
       if: ${{ inputs.skip_cis_scan != 'true' && steps.meta.outputs.scan_image != '' }}
       id: cis_json
-      with:
-        entrypoint: trivy
-        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f json --ignore-unfixed -o ${{ steps.meta.outputs.cis_json_file }}"
+      shell: bash
+      run: |
+        trivy image ${{ env.input }} \
+          ${{ steps.meta.outputs.scan_image }} \
+          --compliance ${{ env.compliance }} \
+          -f json \
+          --ignore-unfixed \
+          -o ${{ steps.meta.outputs.cis_json_file }} \
+          ${{ inputs.trivy_db_cache != '' && '--cache-dir ~/.cache/trivy --skip-db-update' || '' }}
       env:
         compliance: docker-cis-1.6.0
         input: ${{ steps.docker_tar.outputs.files_exists == 'true' && '--input' || '' }}
@@ -324,10 +372,15 @@ runs:
 
     - name: Inspect docker-cis report
       if: ${{ inputs.skip_cis_scan != 'true' && steps.meta.outputs.scan_image != '' }}
-      uses: docker://aquasec/trivy:0.55.2
-      with:
-        entrypoint: trivy
-        args: "image ${{ env.input }} ${{ steps.meta.outputs.scan_image }} --compliance ${{ env.compliance }} -f table --ignore-unfixed --exit-code ${{ env.exit-code }}"
+      shell: bash
+      run: |
+        trivy image ${{ env.input }} \
+          ${{ steps.meta.outputs.scan_image }} \
+          --compliance ${{ env.compliance }} \
+          -f table \
+          --ignore-unfixed \
+          --exit-code ${{ env.exit-code }} \
+          ${{ inputs.trivy_db_cache != '' && '--cache-dir ~/.cache/trivy --skip-db-update' || '' }}
       env:
         exit-code: ${{ (steps.meta.outputs.global_enforce_build_failure == 'true' || inputs.fail_build == 'true') && '1' || '0' }}
         compliance: docker-cis-1.6.0


### PR DESCRIPTION
input which allows caching the Trivy DB to get around rate limiting issues

Trivy (ab)uses GHCR OCI as it's config update mechanism, and this is being heavily (targeted) rate limited by GitHub.

Inspired by https://github.com/aquasecurity/trivy/discussions/7591, this PR adds two optional arguments to the `security-actions/scan-docker-image` image that allows us to skip fetching fro GHCR completely:

```
trivy_db_cache:
    description: 'GitHub repository containing Trivy DB cache (format: owner/repo@ref). Database should be named `db.tar.gz` on the default branch.'
    required: false
trivy_db_cache_token:
    description: 'Token for accessing `trivy_db_cache`.'
    required: false
```

When provided, we will checkout the specific repo's branch using the PAT, look for a `db.tar.gz` file from it and untar it to the filesystem. We then instruct Trivy to not update it's database and instead use the local database only.

This ensures the action will always succeed because a database will always be available. https://github.com/Kong/trivy-db-mirror contains a [workflow](https://github.com/Kong/trivy-db-mirror/blob/master/.github/workflows/update-database.yml) that automatically updates it's database every 6 hours, but update can also be manually triggered via [Run workflow button on this page](https://github.com/Kong/trivy-db-mirror/actions/workflows/update-database.yml).

This PR also removed running Trivy inside the Docker container, as it appears that GitHub Actions does not support volume mounting with the `docker://` method. Instead we simply download the `trivy` executable from the official release link and throw it into `/usr/local/bin`.

According to [my tests](https://github.com/Kong/kong-ee/actions/runs/11683216638/job/32534201531?pr=10626), the scan image workflow now always succeeds.

Sister PR on Kong-ee: https://github.com/Kong/kong-ee/pull/10626