### PR TITLE
feat(SEC-1265): process to sync OCI artifacts from upstream to Kong ECR

### DIFF
--- a/.github/artifactsList.yml
+++ b/.github/artifactsList.yml
@@ -1,0 +1,20 @@
+# This artifact list file is to define the existing security tools which need to be mirrored from upstream
+# within Kong's artifact store.
+# Any future artifacts can also be added here
+
+images:
+  - name: trivy
+    type: image
+    source: docker.io
+    owner: aquasec
+    repo: trivy
+  - name: trivy-db
+    type: oci
+    source: public.ecr.aws
+    owner: aquasecurity
+    repo: trivy-db
+  - name: semgrep
+    type: image
+    source: docker.io
+    owner: returntocorp
+    repo: semgrep

--- a/.github/artifactsList.yml
+++ b/.github/artifactsList.yml
@@ -2,7 +2,7 @@
 # within Kong's artifact store.
 # Any future artifacts can also be added here
 
-images:
+assets:
   - name: trivy
     type: image
     source: docker.io

--- a/.github/scripts/README
+++ b/.github/scripts/README
@@ -1,0 +1,9 @@
+# Sync OCI Artifacts to Kong AWS ECR
+
+A process (GH workflow) within the Public Shared actions repository. The process will be a GH action which will handle mirroring tasks.
+a. The GH action will be scheduled to run every X (i.e default 24h) to check for any version of dependency artifacts available in the Public artifact store(upstream registries).
+b. We will use a utility for OCI compliant tooling (eg: regctl)  for managing the artifact registry associated chores
+c. The utility will pull from public artifact stores(Eg: Dockerhub, ECR, GHCR, Kong managed stores i.e repositories) at the defined interval frequency.
+d. The pulled artifacts will be pushed to stores under the Kong Boundary (Kong AWS Private ECR)  to have granular control on how it is managed and scaled and distributed to consumers (Kong Application pipelines).
+
+More WIP

--- a/.github/scripts/sync_security_artifacts.sh
+++ b/.github/scripts/sync_security_artifacts.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "ACCOUNT_ID: $AWS_ACCOUND_ID"
+
+KONG_ECR_URI="$AWS_ACCOUND_ID.dkr.ecr.us-east-1.amazonaws.com"
+
+# Retrieve the account ID and region from the provided ECR URI
+ACCOUNT_ID=$(echo "$KONG_ECR_URI" | cut -d '.' -f 1)
+REGION=$(echo "$KONG_ECR_URI" | cut -d '.' -f 4)
+
+# Construct the full repository URI for private ECR
+FULL_KONG_ECR_URI="$KONG_ECR_URI"
+
+# Function to check if repository exists
+function check_repository_exists {
+  echo "Checking if repository $REPOSITORY exists in private ECR..."
+  if ! aws ecr describe-repositories --repository-name "$REPOSITORY" --region "$REGION" > /dev/null 2>&1; then
+    echo "Repository $REPOSITORY does not exist. Exiting."
+    exit 1
+  fi
+}
+
+# Function to get the latest tag from upstream
+function get_latest_image_tag_from_upstream {
+  echo "Fetching available tags from the upstream registry for $repo..." >&2
+
+  # Fetch all tags and select the latest (semantic or numeric)
+  latest_tag=$(regctl tag ls "$source/$owner/$repo" | grep -E "^[0-9]+(\.[0-9]+)*$" | sort --version-sort | tail -n 1)
+
+  if [ -z "$latest_tag" ]; then
+    echo "No valid tags found for $repo." >&2
+    return 1
+  fi
+
+  echo "$latest_tag"
+  return 0
+}
+
+# Function to pull an image or OCI artifact using regctl
+function pull_artifact {
+  echo "Pulling $type from $source with regctl..."
+  regctl image copy "$source/$owner/$repo:$tag" "$FULL_KONG_ECR_URI/$REPOSITORY:$tag"
+}
+
+# Main script
+SECURITY_ARTIFACTS_CONFIG_FILE=".github/artifactsList.yml"
+ARTIFACTS=$(yq -r '.images[] | "\(.name)|\(.type)|\(.source)|\(.owner)|\(.repo)"' "$SECURITY_ARTIFACTS_CONFIG_FILE")
+
+echo "$ARTIFACTS" | while IFS="|" read -r name type source owner repo; do
+  REPOSITORY="$name"
+  echo "Repo name is = $REPOSITORY"
+
+  # Check if the repository exists in private ECR
+  echo "Check if the repository exists in private ECR"
+  check_repository_exists
+
+  # Get the latest upstream tag
+  echo "Get the latest upstream tag, function run get_latest_upstream_tag"
+  tag=$(get_latest_image_tag_from_upstream)
+
+  # Pull and push the latest tag to ECR, overwriting if it already exists
+  echo "Pulling and pushing the latest tag: $tag for $name"
+  pull_artifact
+
+done

--- a/.github/scripts/sync_security_artifacts.sh
+++ b/.github/scripts/sync_security_artifacts.sh
@@ -46,7 +46,7 @@ function pull_artifact {
 
 # Main script
 SECURITY_ARTIFACTS_CONFIG_FILE=".github/artifactsList.yml"
-ARTIFACTS=$(yq -r '.images[] | "\(.name)|\(.type)|\(.source)|\(.owner)|\(.repo)"' "$SECURITY_ARTIFACTS_CONFIG_FILE")
+ARTIFACTS=$(yq -r '.assets[] | "\(.name)|\(.type)|\(.source)|\(.owner)|\(.repo)"' "$SECURITY_ARTIFACTS_CONFIG_FILE")
 
 echo "$ARTIFACTS" | while IFS="|" read -r name type source owner repo; do
   REPOSITORY="$name"

--- a/.github/workflows/sync_security_artifacts.yml
+++ b/.github/workflows/sync_security_artifacts.yml
@@ -1,0 +1,48 @@
+name: Multi-Registry Artifact Sync
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sync_images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-private-role
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+
+      - name: Sts GetCallerIdentity
+        run: |
+            aws sts get-caller-identity
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y python3-pip
+          pip3 install yq
+          chmod +x .github/scripts/sync_security_artifacts.sh
+
+      - name: Install regctl
+        uses: regclient/actions/regctl-installer@main
+        
+      - name: Execute the image sync script
+        run: |
+          ./.github/scripts/sync_security_artifacts.sh "${{ steps.login-ecr.outputs.registry }}"
+        env:
+          AWS_ACCOUND_ID: ${{ secrets.AWS_ACCOUNT_ID }}


### PR DESCRIPTION
# Feature: Automated Sync of Security Tool Artifacts to AWS ECR
## Overview
This PR introduces an automated workflow to synchronise security artifacts from upstream public registries to our private AWS ECR registry. The synchronisation ensures that our security artifacts are up-to-date, enhancing our security posture.

## Changes Introduced
* New Workflow: Added `.github/workflows/sync_security_artifacts.yml`
   * *Schedule*: Runs every 24 hours using GitHub Actions' scheduled workflows.
   * *AWS Authentication*: Utilizes AWS actions to authenticate with AWS and ECR.
   * *Script Execution*: Executes the bash script located at `.github/scripts/sync_security_artifacts.sh`.
   
* Bash Script: Created `.github/scripts/sync_security_artifacts.sh`
   * Syncs artifacts from upstream public registries to our private AWS ECR.
   * Reads the list of artifacts from artifactsList.yml.

* Artifacts Index: Added `artifactsList.yml`
  * Contains a list of existing and future assets to be synchronised.
  * Facilitates easy updates to the list of artifacts without modifying the script.
