### PR TITLE
chore(sign-docker-image): set issuer to github-action

### DIFF
--- a/security-actions/sign-docker-image/action.yml
+++ b/security-actions/sign-docker-image/action.yml
@@ -118,6 +118,8 @@ runs:
           -a "repo=${{ github.repository }}" \
           -a "workflow=${{ github.workflow }}" \
           -a "sha=${{ github.sha }}" \
+          --oidc-provider=github-actions \
+          --oidc-issuer=https://token.actions.githubusercontent.com \
           "$img"@${{ env.IMAGE_DIGEST }}
         done
 


### PR DESCRIPTION
In Kuma, we occasionally encounter an issue while signing images, as seen in this workflow: [GitHub Actions Run](https://github.com/kumahq/kuma/actions/runs/12741786325/job/35513880546).

It appears that the token sometimes enters a verification mode, prompting the following message:
> Enter the verification code DZXT-XKLG in your browser at: https://oauth2.sigstore.dev/auth/device?user_code=DZXT-XKLG.

Upon investigating, I found a relevant discussion on the issue: [Sigstore Cosign Issue #1258](https://github.com/sigstore/cosign/issues/1258#issuecomment-1684227935).


```
Retrieving signed certificate...
Non-interactive mode detected, using device flow.
Enter the verification code DZXT-XKLG in your browser at: https://oauth2.sigstore.dev/auth/device?user_code=DZXT-XKLG
Code will be valid for 300 seconds
Error: signing [docker.io/kumahq/kuma-cp@sha256:f1798ae5df07acf3968a23f44fd73e1d47ba998ad1ec2612efb92ba752ead4ec]: getting signer: getting key from Fulcio: retrieving cert: error obtaining token: expired_token
main.go:74: error during command execution: signing [docker.io/kumahq/kuma-cp@sha256:f1798ae5df07acf3968a23f44fd73e1d47ba998ad1ec2612efb92ba752ead4ec]: getting signer: getting key from Fulcio: retrieving cert: error obtaining token: expired_token
```
