### PR TITLE
feat(deps): ignore commitlint check for dependabot messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,5 +13,11 @@ module.exports = {
       [...(await getPackages(ctx)), 'release', 'deps', 'ci']
     ]
   },
+  // TODO: Add a custom ignore function to ignore Dependabot commits
+  // Temporary solution: Ignore function to ignore any commit message which match the regex.
+  // Example commit message: `github-actions(deps): bump anchore/scan-action from 4.1.2 to 6.1.0` 
+  ignores: [
+    (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
+  ],
   helpUrl: 'https://github.com/Kong/public-shared-actions',
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,7 +13,7 @@ module.exports = {
       [...(await getPackages(ctx)), 'release', 'deps', 'ci']
     ]
   },
-  // TODO: Add a custom ignore function to ignore Dependabot commits
+// TODO:  Perform ignores based on Commit Author instead of Message to avoid spoofing
   // Temporary solution: Ignore function to ignore any commit message which match the regex.
   // Example commit message: `github-actions(deps): bump anchore/scan-action from 4.1.2 to 6.1.0` 
   ignores: [


### PR DESCRIPTION
## What this PR does?
- Updates commitlint config file to ignore commit messages in the format `github-actions(deps): bump anchore/scan-action from 4.1.2 to 6.1.0`. These commit messages are generally used by Dependabot while raise PRs for version bump for upstream dependencies. 

## Why to use ignore?
The CI workflows have been failing for Dependabot. Ref below failed example https://github.com/Kong/public-shared-actions/actions/runs/12938518475/job/36088812115?pr=217
```
Error: You have commit messages with errors

⧗   input: github-actions(deps): bump anchore/scan-action in /security-actions/sca

Bumps [anchore/scan-action](https://github.com/anchore/scan-action) from 4.1.2 to 6.1.0.
- [Release notes](https://github.com/anchore/scan-action/releases)
- [Changelog](https://github.com/anchore/scan-action/blob/main/RELEASE.md)
- [Commits](https://github.com/anchore/scan-action/compare/64a33b277ea7a[12](https://github.com/Kong/public-shared-actions/actions/runs/12938518475/job/36088812115?pr=217#step:7:13)15a3c142735a109[13](https://github.com/Kong/public-shared-actions/actions/runs/12938518475/job/36088812115?pr=217#step:7:14)41939ff5...7c05671ae9be166aeb155bad2d7df9121823df32)

---
updated-dependencies:
- dependency-name: anchore/scan-action
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]
✖   scope may not be empty [scope-empty]

✖   found 4 problems, 0 warnings
ⓘ   Get help: https://github.com/Kong/public-shared-actions
```