### PR TITLE
chore(ci): bump trivy from v0.57.1 to v0.58.2

### DIFF
--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -324,7 +324,7 @@ runs:
     - name: Install Trivy
       shell: bash
       run: |
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.57.1
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.58.2
 
     - name: Checkout Trivy DB cache
       if: inputs.trivy_db_cache != ''


### PR DESCRIPTION
- Bump trivy version to  [v0.58.2](https://github.com/aquasecurity/trivy/releases/tag/v0.58.2)
- Include [fix](https://github.com/aquasecurity/trivy/blob/release/v0.58/CHANGELOG.md#bug-fixes-1) for intermittent [UNKNOWN_BLOB error](https://github.com/Kong/kauth-pdp/actions/runs/13661154051/job/38192998446) during image DB pulls using automatic fallback to other DB mirror registries. 