### PR TITLE
fix(scan-docker-image): disable trivy exit-code for docker-cis

### DIFF
--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -384,9 +384,7 @@ runs:
           --compliance ${{ env.compliance }} \
           -f table \
           --ignore-unfixed \
-          --exit-code ${{ env.exit-code }} \
           ${{ inputs.trivy_db_cache != '' && '--cache-dir ~/.cache/trivy --skip-db-update' || '' }}
       env:
-        exit-code: ${{ (steps.meta.outputs.global_enforce_build_failure == 'true' || inputs.fail_build == 'true') && '1' || '0' }}
         compliance: docker-cis-1.6.0
         input: ${{ steps.docker_tar.outputs.files_exists == 'true' && '--input' || '' }}


### PR DESCRIPTION
# Issue:  
The Docker CIS [image scan ](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38711656958) for `amazonlinux 2023` failed. I'm not sure if that's the actual error.

The trivy command [--exit-code 1](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38714374490#step:7:504)  was ideally supposed to be applied on failures in [CIS compliance checks](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38714374490#step:7:501). 

The result from [Docker image CIS checks](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38714374490#step:7:529)  doesn't have any failures.

However, the output is deceptive, and only displays the results of compliance checks and NOT the findings from default scanners that misleads us why the --exit-code 1 was applied to fail the build when there were [NO failures in CIS checks](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38714374490#step:7:529).

# Analysis
- Inspecting [[493:495](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38714374490#step:7:519)], found that trivy runs the default scanners like vuln,config,secret [[494:496](https://github.com/Kong/kong-ee/actions/runs/13834989248/job/38714374490#step:7:520)] alongside with docker CIS compliance flag checks and doesn't support overriding/skipping these default scanners when --compliance docker-cis-1.6.0  is specified.

- On a closer look, the only the scan-image job for `amazonlinux-2023` failed and other all distros succeeded even with input `--exit-code 1` and  NO failures in  docker CIS results.

- On running trivy locally, without the `--compliance`  flag on amazonlinux-2023 and amzonlinux-2 (refer screenshots attached) the default scanners were enabled and findings were found only on amazonlinux-2023 . The --exit-code 1 was being applied on these  hidden default scanner findings that were not displayed when --compliance flag is specified.

# Fix
Trivy is leveraged to run DOCKER CIS.  The exit code input of trivy cannot be configured exclusively on failures of findings from docker cis benchmark check and there is no way to disable / override default vulnerability scanners.

This fix disables the setting the exit code for any trivy docker CIS findings.

#### Screenshots
-  Result without --compliance flag but with `--exit-code` enabled on findings from default scanners findings for `amazonlinux-2023`
<img width="1724" alt="Screenshot 2025-03-13 at 5 14 54 PM" src="https://github.com/user-attachments/assets/9c00eb91-652d-4fe4-9e27-9c7a8dfae74b" />
-  Result without --compliance flag but with `--exit-code` enabled. However, there are No findings from default scanners for `amazonlinux-2`
<img width="1728" alt="Screenshot 2025-03-13 at 5 14 19 PM" src="https://github.com/user-attachments/assets/fb78aa31-6e46-4530-a59f-6676ee338b63" />


- Result with --compliance flag but with no CIS failures but `--exit-code` still enabled on findings from default scanner for `amazonlinux-2023` which can't be skipped/overridden
<img width="1728" alt="Screenshot 2025-03-13 at 5 50 35 PM" src="https://github.com/user-attachments/assets/aabb236a-2150-4ad2-bf27-46d77b216ac4" />
- Result with --compliance flag but with no CIS failures  and No findings from default scanners but `--exit-code` still enabled for `amazonlinux-2` that passes the build on this distro
<img width="1726" alt="Screenshot 2025-03-13 at 5 50 56 PM" src="https://github.com/user-attachments/assets/78d81d80-bcfa-428b-9541-c3eb40f205bc" />


