### PR TITLE
fix(lua): use forked kong-gateway luacheck action

### DIFF
--- a/.github/workflows/lua-lint.yml
+++ b/.github/workflows/lua-lint.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches:
     - main
+    paths:
+    - code-check-actions/lua-*/**
   push:
     branches:
     - main
     tags:
     - '*'
+    paths:
+    - code-check-actions/lua-*/**
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches:
     - main
+    paths:
+    - code-check-actions/rust-*/**
   push:
     branches:
     - main
     tags:
     - '*'
+    paths:
+    - code-check-actions/rust-*/**
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/rust-sca.yml
+++ b/.github/workflows/rust-sca.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches:
     - main
+    paths:
+    - code-check-actions/rust-*/**
   push:
     branches:
     - main
     tags:
     - '*'
+    paths:
+    - code-check-actions/rust-*/**
   workflow_dispatch: {}
 
 jobs:

--- a/code-check-actions/lua-lint/action.yml
+++ b/code-check-actions/lua-lint/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Run Luacheck for static analysis
-      uses: lunarmodules/luacheck@ababb6d403d634eb74d2c541035e9ede966e710d
+      uses: kong-gateway/luacheck@ababb6d403d634eb74d2c541035e9ede966e710d # 1.1.1
       continue-on-error: true
       with:
         args: "${{ inputs.additional_args }} --codes --ranges --formatter JUnit -q ${{ inputs.files }} > luacheck_${{github.sha}}.xml"


### PR DESCRIPTION
Encountered the need for this while migrating [lua-resty-azure](https://github.com/kong-gateway/lua-resty-azure).

Because https://github.com/orgs/kong-gateway has stricter rules about 3rd party actions, https://github.com/kong-gateway/lua-resty-azure/blob/main/.github/workflows/lint.yml was throwing:

![CleanShot 2025-07-08 at 10 11 56](https://github.com/user-attachments/assets/620ec6f6-def3-47b2-8e49-b8bfeab3a298)

```
Error: Bad request - lunarmodules/luacheck@ababb6d403d634eb74d2c541035e9ede966e710d and enricomi/publish-unit-test-result-action@v2 are not allowed to be used in kong-gateway/lua-resty-azure. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: kong/*.
```