### PR TITLE
fix/download grype binary

### DIFF
--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -137,7 +137,9 @@ runs:
         echo "::endgroup::"
 
     - name: Download Grype
-      uses: anchore/scan-action/download-grype@16910ac423301c6d30554b83a7f71ac6ff4a51f3 # v6.4.0
+      shell: bash
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.96.1
 
     # Skip Cache Restoration: If skip_grype_db_cache is true, skip the restoration of the cache.
     # Check for any existing cache to reuse

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -155,10 +155,9 @@ runs:
         echo "::endgroup::"
     
     - name: Download Grype
-      # uses: anchore/scan-action/download-grype@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # v6.2.0
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.92.2
+        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.96.1
 
     # Skip Cache Restoration: If skip_grype_db_cache is true, skip the restoration of the cache.
     # Check for any existing cache to reuse


### PR DESCRIPTION
## Fix: Replace download-grype GitHub Action with direct binary install

## Changes
This PR updates the Grype setup step with the followings:
* Installs Grype binary version `v0.96.1` to `/usr/local/bin` using curl in `sca` action instead of downloading it via `anchore/scan-action/download-grype`
* Update Grype binary version in `scan-docker-image` action
* Ensures grype is available in PATH for all subsequent steps

## Motivation
The `download-grype` GitHub Action does not automatically add the Grype binary to the system `PATH`, causing `command not found` errors in follow-up steps. Installing it directly solves this and provides better control over the binary path and version. 
 
Additionally, installing CLI tools directly (instead of relying on wrapper actions) has been choosen to be the preferred pattern for consistency and flexibility. This approach is already followed in `scan-docker-image` action, where Grype is installed via curl.