### PR TITLE
chore(ci): use unscoped package names for git release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Shared actions available to both public and private repositories
 ## Usage
   
 ```yaml
-- uses: Kong/public-shared-actions/<action-name>@<tag>
+- uses: Kong/public-shared-actions/<action-name>@<SHA>
 ```
 
 For example:

--- a/code-build-actions/build-js-sdk/package.json
+++ b/code-build-actions/build-js-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@code-build-actions/build-js-sdk",
+  "name": "build-js-sdk",
   "version": "4.0.1",
   "description": "This action builds a JavaScript SDK and updates an existing PR with the generated files",
   "main": "index.js",

--- a/code-check-actions/lua-lint/package.json
+++ b/code-check-actions/lua-lint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@code-check-actions/lua-lint",
+  "name": "lua-lint",
   "version": "4.0.2",
   "description": "This action analyzes all changed lua files using [lunarmodules/luacheck](https://github.com/lunarmodules/luacheck)",
   "main": "index.js",

--- a/code-check-actions/rust-lint/package.json
+++ b/code-check-actions/rust-lint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@code-check-actions/rust-lint",
+  "name": "rust-lint",
   "version": "4.1.1",
   "description": "This action uses Rust Clippy for code quality checks",
   "main": "index.js",

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
   "command": {
     "version": {
       "message": "chore(release): publish [skip ci]",
-      "allowBranch": ["main","fix/release-names"],
+      "allowBranch": ["main"],
       "conventionalCommits": true,
       "changelogPreset": "metahub"
     }

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
   "command": {
     "version": {
       "message": "chore(release): publish [skip ci]",
-      "allowBranch": ["main"],
+      "allowBranch": ["main","fix/release-names"],
       "conventionalCommits": true,
       "changelogPreset": "metahub"
     }

--- a/pr-previews/cleanup/package.json
+++ b/pr-previews/cleanup/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pr-previews/cleanup",
+  "name": "pr-previews-cleanup",
   "version": "4.0.1",
   "description": "Deprecate and unpublish PR preview package versions for closed PRs",
   "main": "index.js",

--- a/pr-previews/up-to-date/package.json
+++ b/pr-previews/up-to-date/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pr-previews/up-to-date",
+  "name": "pr-previews-up-to-date",
   "version": "4.0.0",
   "description": "Is/was the PR associated with the workflow commit up to date? Works for open PRs and Squash Merges.",
   "main": "index.js",

--- a/pr-previews/validate/package.json
+++ b/pr-previews/validate/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pr-previews/validate",
+  "name": "pr-previews-validator",
   "version": "4.0.0",
   "description": "Checks all package.json files in repository and throws error is detects any dependency on PR preview package",
   "main": "index.js",

--- a/security-actions/sca/package.json
+++ b/security-actions/sca/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@security-actions/sca",
+  "name": "sca",
   "version": "4.1.4",
   "description": "a unified action for composition analysis. The action produces an SBOM, CVE reports for a given image / directory / file.",
   "main": "index.js",

--- a/security-actions/scan-docker-image/package.json
+++ b/security-actions/scan-docker-image/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@security-actions/scan-docker-image",
+  "name": "scan-docker-image",
   "version": "4.2.4",
   "description": "The repo generates SBOMs & scans Docker images for CVE, CIS",
   "main": "index.js",

--- a/security-actions/scan-gh-workflows/package.json
+++ b/security-actions/scan-gh-workflows/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@security-actions/scan-gh-workflows",
+  "name": "scan-gh-workflows",
   "version": "4.1.2",
   "description": "The package scans github actions and workflows for anti-patterns",
   "main": "index.js",

--- a/security-actions/scan-rust/package.json
+++ b/security-actions/scan-rust/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@security-actions/scan-rust",
+  "name": "scan-rust",
   "version": "4.1.1",
   "description": "This action uses Grype for source code analysis. It will only support scanning source code directories / files and will not support the container images",
   "main": "index.js",

--- a/security-actions/sign-docker-image/package.json
+++ b/security-actions/sign-docker-image/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@security-actions/sign-docker-image",
+  "name": "sign-docker-image",
   "version": "4.1.2",
   "description": "A unified action for container image signing. The action leverages keyless signing to produce an Signature and uploads to Docker Image layer and Public Rekor for transaprency",
   "main": "index.js",

--- a/slack-actions/workflow-notification/package.json
+++ b/slack-actions/workflow-notification/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@slack-actions/workflow-notification",
+  "name": "slack-workflow-notification",
   "version": "4.0.1",
   "description": "Slack notification workflow",
   "main": "index.js",


### PR DESCRIPTION
# Summary
- Change to use 'unscoped' package naming convention for release tags

## Why this change ?
- standardize release tags conventions across internal and public shared actions
- helps streamline standard preset for renovate configs across internal and public shared actions
- Although SHA is recommended over using release tag names,  it avoids the GH nuance of failing to fetch release tags with the format: `Kong/public-shared-actions/security-actions/scan-docker-image@@security-actions/sca@4.1.4` including `double @`

## Breaking Change:
Applications and Package managers using:
- Release Tag names will need update the package names to new format
- Pinned SHA  are NOT affected