### PR TITLE
feat(scan-docker-image): add by-cve flag to organise results by CVE

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -66,6 +66,7 @@ jobs:
         skip_cis_scan: false
         trivy_db_cache: Kong/trivy-db-mirror@master
         trivy_db_cache_token: ${{ secrets.SECURITY_BOT_PSA_PAT }}
+        by_cve: true
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''

--- a/security-actions/scan-docker-image/README.md
+++ b/security-actions/scan-docker-image/README.md
@@ -133,6 +133,10 @@ permissions:
   trivy_db_cache_token:
     description: 'Token for accessing `trivy_db_cache`.'
     required: false
+  by_cve:
+    description: 'Specify whether to orient results by CVE rather than GHSA'
+    required: false
+    default: 'false'
 ```
 
 #### Output specification
@@ -256,8 +260,10 @@ jobs:
       uses: Kong/public-shared-actions/security-actions/scan-docker-image@main
       with:
         # Leverages trivy DB config from upstream mirror by default
+        # Results are organized by CVE IDs (Common Vulnerabilities and Exposures identifiers) when `by_cve` is set to true
         asset_prefix: kong-gateway-dev-linux-amd64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
+        by_cve: true 
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
@@ -267,5 +273,5 @@ jobs:
         asset_prefix: kong-gateway-dev-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
         trivy_db_cache: <owner/repo@ref>
-        trivy_db_cache_token: ${{ secrets.PAT }} 
+        trivy_db_cache_token: ${{ secrets.PAT }}
 ```

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -73,6 +73,10 @@ inputs:
   trivy_db_cache_token:
     description: 'Token for accessing `trivy_db_cache`.'
     required: false
+  by_cve:
+    description: 'Specify whether to orient results by CVE rather than GHSA'
+    required: false
+    default: 'false'
 
 outputs:
   cis-json-report:
@@ -244,6 +248,7 @@ runs:
         fail-build: 'false'
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+        by-cve: ${{ inputs.by_cve }}
       env:
         GRYPE_DB_AUTO_UPDATE: false # Use grype db pointed from grype_db step above
 
@@ -259,6 +264,7 @@ runs:
         fail-build: 'false'
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+        by-cve: ${{ inputs.by_cve }}
       env:
         GRYPE_DB_AUTO_UPDATE: false # Use grype db pointed from grype_db step above
 
@@ -320,6 +326,7 @@ runs:
         fail-build: ${{ steps.meta.outputs.global_enforce_build_failure == 'true' && steps.meta.outputs.global_enforce_build_failure || inputs.fail_build }}
         add-cpes-if-none: true
         severity-cutoff: ${{ steps.meta.outputs.global_severity_cutoff }}
+        by-cve: ${{ inputs.by_cve }}
       env:
         GRYPE_DB_AUTO_UPDATE: false # Use grype db pointed from grype_db step above
 


### PR DESCRIPTION
# Add `by-cve` flag support to vulnerability scanning action
## Motivation
Expose the `by-cve` flag to allow downstream workflows to orient vulnerability results by CVE identifiers instead of GHSA identifiers.

## Changes
* Add `by-cve` input parameter to the Grype scanning action