### PR TITLE
fix: SCA action grype DB should be downloaded at least daily

### DIFF
--- a/security-actions/sca/action.yml
+++ b/security-actions/sca/action.yml
@@ -162,6 +162,11 @@ runs:
       env:
         grype: ${{ steps.grype.outputs.grype-path }}
 
+    - name: Get current date
+      id: date
+      shell: bash
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
     # Explicitly check for Grype DB in Git Cache
     - name: Check Git Cache for Grype DB
       id: grype_db_git_cache
@@ -169,8 +174,9 @@ runs:
       with:
         # Grype cache files are stored in `~/.cache/grype/db` on Linux/macOS
         path: ~/.cache/grype/db
+        # Given the DB should not be less than 5 days old let's refetch it at least once per day
         key: |
-          cache_grype_db_v${{ steps.grype_metadata.outputs.grype_db_schema }}
+          cache_grype_db_v${{ steps.grype_metadata.outputs.grype_db_schema }}_${{ steps.date.outputs.date }}
 
      # Explicitly check for Grype DB in specified mirror
     - name: Parse Grype DB cache input


### PR DESCRIPTION
In case in a repo we are not over the 10GB limit for GitHub actions cache, thus the security database never gets outdated, the database never gets updated. see this [run](https://github.com/openmeterio/openmeter/actions/runs/18274917328/job/52024699148)

This patch makes sure to use a cache key that is day specific to force one fetch per day.

This is a common pattern used by other solutions:
- https://github.com/aquasecurity/trivy-action/blob/master/action.yaml#L135C1-L146
- golangcilint

Right now given on cache hit we are not updating the DB, I am not using the key/restore-key distinction.