### PR TITLE
fix(ci): bumping actions to prevent node 20 warning []KHCP-20416]

### DIFF
--- a/code-check-actions/lua-lint/README.md
+++ b/code-check-actions/lua-lint/README.md
@@ -9,10 +9,10 @@ This action looks for any `cli` arguments and a deafult `.luacheckrc` config to 
 ## Inputs
 
 ```yaml
-additional_args: 
+additional_args:
     description: 'Arguments to luacheck'
     required: 'false'
-    default: '.' # Default: Run luacheck on workspace dir 
+    default: '.' # Default: Run luacheck on workspace dir
 ```
 
 ## Outputs
@@ -55,15 +55,15 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    
+
     # Optional step to run on only changed files
     - name: Get changed files
       id: changed-files
-      uses: kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
-      with: 
+      uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
+      with:
         files: |
           **.lua
-    
+
     - name: Lua Check
       if: steps.changed-files.outputs.any_changed == 'true'
       uses: Kong/public-shared-actions/code-check-actions/luacheck@main

--- a/pr-previews/audit/action.yaml
+++ b/pr-previews/audit/action.yaml
@@ -90,7 +90,7 @@ runs:
         inputs.pnpm-audit == 'true'
       id: pnpm-audit
       continue-on-error: true
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #7.1.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
@@ -198,7 +198,7 @@ runs:
       if: |
         inputs.check-renovate-security-pr == 'true' ||
         inputs.check-renovate == 'true'
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #7.1.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
@@ -252,7 +252,7 @@ runs:
       continue-on-error: true
       if: |
         inputs.check-test-coverage == 'true'
-      uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+      uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
       with:
         files_yaml: ${{ inputs.test-coverage-files }}
 
@@ -261,7 +261,7 @@ runs:
       if: |
         inputs.check-test-coverage == 'true'
       continue-on-error: true
-      uses: actions/github-script@v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
@@ -339,7 +339,7 @@ runs:
 
     - name: Collect results
       id: collect-results
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #7.1.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |

--- a/pr-previews/audit/action.yaml
+++ b/pr-previews/audit/action.yaml
@@ -67,7 +67,7 @@ runs:
   using: composite
   steps:
     - name: Remove audit PR comments
-      uses: Kong/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+      uses: Kong/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
         header: pr-audit
         delete: true
@@ -440,7 +440,7 @@ runs:
     - name: Create PR comment
       if: |
         steps.collect-results.outputs.results != ''
-      uses: Kong/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+      uses: Kong/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
         header: pr-audit
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}


### PR DESCRIPTION
This is to prevent node 20 deprecation warning 
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a, Kong/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db.
```