### PR TITLE
chore(runtime): bump node.js to 24

### DIFF
--- a/code-check-actions/lua-lint/action.yml
+++ b/code-check-actions/lua-lint/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Upload results to workflow
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: luacheck_results.zip
         path: |

--- a/security-actions/scan-docker-image/action.yml
+++ b/security-actions/scan-docker-image/action.yml
@@ -100,7 +100,7 @@ runs:
 
     # Must upload artifact for output file parameter to have effect
     - name: Generate SPDX SBOM Using Syft
-      uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       id: sbom_spdx
       with:
         config: ${{ inputs.config }}
@@ -116,7 +116,7 @@ runs:
         github-token: ${{ inputs.github-token }}
 
     - name: Generate CycloneDX SBOM Using Syft
-      uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       id: sbom_cyclonedx
       with:
         config: ${{ inputs.config }}
@@ -152,7 +152,7 @@ runs:
     # Instead handled explicitly to try from mirror before reaching upstream for more realiability
     - name: Install Grype
       id: grype_install
-      uses: anchore/scan-action/download-grype@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+      uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       with:
         cache-db: false
 
@@ -184,7 +184,7 @@ runs:
     # Explicitly check for Grype DB in Git Cache
     - name: Check Git Cache for Grype DB
       id: grype_db_git_cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         # Grype cache files are stored in `~/.cache/grype/db` on Linux/macOS
         path: ~/.cache/grype/db
@@ -257,7 +257,7 @@ runs:
     # Grype is invoked first time ever
     # Don't fail during report generation
     - name: Vulnerability analysis of SBOM
-      uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       id: grype_analysis_sarif
       if: ${{ steps.sbom_report.outputs.files_exists == 'true' && steps.grype_db_status.outputs.db_status == '0' }}
       with:
@@ -274,7 +274,7 @@ runs:
     # Don't fail during report generation
     # JSON format will report  any ignored rules
     - name: Vulnerability analysis of SBOM
-      uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       id: grype_analysis_json
       if: ${{ steps.sbom_report.outputs.files_exists == 'true' && steps.grype_db_status.outputs.db_status == '0' }}
       with:
@@ -314,7 +314,7 @@ runs:
         mv ${{ steps.grype_analysis_json.outputs.json }} ${{ steps.meta.outputs.grype_json_file }}
 
     - name: Upload grype analysis report
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.meta.outputs.grype_sarif_file }}
         path: |
@@ -323,7 +323,7 @@ runs:
 
     # Upload grype cve reports
     - name: Upload grype analysis report
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.meta.outputs.grype_json_file }}
         path: |
@@ -334,7 +334,7 @@ runs:
     # Notify grype quick scan results in table format
     # Table format will supress any specified ignore rules
     - name: Inspect Vulnerability analysis of SBOM
-      uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       if: ${{ steps.sbom_report.outputs.files_exists == 'true' && steps.grype_db_status.outputs.db_status == '0' }}
       with:
         sbom: ${{ steps.meta.outputs.sbom_spdx_file }}
@@ -423,7 +423,7 @@ runs:
 
     - name: upload docker-cis JSON report
       if: ${{ inputs.skip_cis_scan != 'true' && steps.meta.outputs.scan_image != '' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.meta.outputs.cis_json_file }}
         path: |

--- a/security-actions/semgrep/action.yml
+++ b/security-actions/semgrep/action.yml
@@ -46,7 +46,7 @@ runs:
     # Upload grype cve reports
     - name: Upload Semgrep to Workflow
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: semgrep_sast.zip
         path: |
@@ -56,7 +56,7 @@ runs:
 
     - name: Upload SARIF to Github Code Scanning
       if: ${{ always() && inputs.codeql_upload == 'true' && github.event.repository.visibility == 'public' }}
-      uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.7
+      uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: semgrep_${{github.sha}}.sarif

--- a/security-actions/sign-docker-image/action.yml
+++ b/security-actions/sign-docker-image/action.yml
@@ -87,7 +87,7 @@ runs:
     # By default cosign publishes image signatures alongside image repositories in the same registry
     # This step is needed for pulling image from / pushing image sig to private registry
     - name: Login to Image Registry - ${{ inputs.image_registry_domain }}
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       if: ${{ inputs.registry_username != '' && inputs.registry_password != '' }}
       with:
         registry: ${{ inputs.image_registry_domain }}
@@ -96,7 +96,7 @@ runs:
     
     # This step runs if signature registry is different from image registry
     - name: Login to Signature Registry - ${{ inputs.signature_registry_domain }}
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       if: ${{ inputs.signature_registry_username != '' && inputs.signature_registry_password != '' }}
       with:
         registry: ${{ inputs.signature_registry_domain }}
@@ -126,7 +126,7 @@ runs:
      # Upload Cosign Artifacts (public cert and signatures)
      # Uploaded artifact name must be unique across each workflow run / job
     - name: Upload Cosign Artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.local_save_cosign_assets == 'true' && inputs.cosign_output_prefix != '' }}
       with:
         name: signed-image-assets-${{inputs.cosign_output_prefix}}


### PR DESCRIPTION
Raise the repository runtime baseline to Node.js 24. Align the version pin, package engines, and custom action runtimes on the same major version.

Background: 

> Node.js 20 actions are deprecated.
>
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
>
> Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24.
> 
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> 
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/